### PR TITLE
MakeLists: Define RUST_TARGET_PATH for xargo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ ExternalProject_Add(
   "CONFIG_USERSPACE=${CONFIG_USERSPACE}"
   "TARGET_CFLAGS=${external_project_cflags} --target=${clang_target}"
   "XARGO_HOME=${rust_build_dir}/xargo"
+  "RUST_TARGET_PATH=${rust_src_dir}"
   xargo +nightly build --target=${rust_target} --target-dir=${rust_build_dir} --release
   INSTALL_COMMAND ""
   BUILD_BYPRODUCTS ${rust_staticlib}


### PR DESCRIPTION
Fixes issues with compiling external crates and not being able to find
the zephyr rust toolchain.