### PR TITLE
zephyr-bindgen: split build.rs into its own project

### DIFF
--- a/rust-app/zephyr-sys/Cargo.toml
+++ b/rust-app/zephyr-sys/Cargo.toml
@@ -5,6 +5,3 @@ authors = ["Tyler Hall <tylerwhall@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-
-[build-dependencies]
-bindgen = "0.49.0"

--- a/rust-app/zephyr-sys/build.rs
+++ b/rust-app/zephyr-sys/build.rs
@@ -1,114 +1,16 @@
-extern crate bindgen;
-
 use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
-
-use bindgen::callbacks::ParseCallbacks;
-
-#[derive(Debug, Default)]
-struct CallbacksInner {
-    /// k_impl_* real functions that bindgen picked up
-    kernel: Vec<String>,
-    /// z_anyctx_* definitions that we generate for every syscall
-    user: Vec<String>,
-}
-#[derive(Clone, Debug, Default)]
-struct Callbacks(Arc<Mutex<CallbacksInner>>);
-
-impl ParseCallbacks for Callbacks {
-    fn item_name(&self, name: &str) -> Option<String> {
-        const KERNEL: &str = "z_impl_";
-        const ANY: &str = "z_anyctx_";
-        let mut inner = self.0.lock().unwrap();
-        if name.starts_with(KERNEL) {
-            inner.kernel.push(name[KERNEL.len()..].into());
-        } else if name.starts_with(ANY) {
-            inner.user.push(name[ANY.len()..].into());
-        }
-        None
-    }
-}
 
 fn main() {
-    let flags = env::var("TARGET_CFLAGS").unwrap_or("".to_string());
-    eprintln!("cflags: {}", flags);
-    let userspace = env::var("CONFIG_USERSPACE").expect("CONFIG_USERSPACE must be set") == "y";
-    eprintln!("userspace: {}", userspace);
-
-    let callbacks = Callbacks::default().clone();
-    // The bindgen::Builder is the main entry point
-    // to bindgen, and lets you build up options for
-    // the resulting bindings.
-    let bindings = bindgen::Builder::default()
-        // The input header we would like to generate
-        // bindings for.
-        .header("wrapper.h")
-        .use_core()
-        .ctypes_prefix("super::ctypes")
-        .parse_callbacks(Box::new(callbacks.clone()))
-        // XXX: doesn't handle args with spaces in quotes
-        .clang_args(flags.split(" "))
-        .blacklist_item(".*x86_mmu.*")
-        .blacklist_item(".*x86_.*pdpt")
-        // Finish the builder and generate the bindings.
-        .generate()
-        // Unwrap the Result and panic on failure.
-        .expect("Unable to generate bindings");
-
-    // Write the bindings to the $OUT_DIR/bindings.rs file.
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-    bindings
-        .write_to_file(out_path.join("bindings.rs"))
-        .expect("Couldn't write bindings!");
-
-    // Namespace aliases to syscalls by their valid contexts
-    let mut out = File::create(out_path.join("syscalls.rs")).unwrap();
-    let syscalls = callbacks.0.lock().unwrap();
-    writeln!(&mut out, "pub mod kernel {{").unwrap();
-    for syscall in syscalls.kernel.iter() {
-        if syscalls.user.iter().any(|c| c == syscall) {
-            writeln!(
-                &mut out,
-                "    pub use super::super::raw::z_impl_{} as {};",
-                syscall, syscall
-            )
-            .unwrap();
-        }
-    }
-    writeln!(&mut out, "}}").unwrap();
-    writeln!(&mut out, "pub mod user {{").unwrap();
-    if userspace {
-        // If userspace enabled, output each userspace-context syscall here
-        for syscall in syscalls.user.iter() {
-            writeln!(
-                &mut out,
-                "    pub use super::super::raw::z_userctx_{} as {};",
-                syscall, syscall
-            )
-            .unwrap();
-        }
-    } else {
-        // Else, import all the kernel functions since they can be called directly
-        writeln!(&mut out, "pub use super::kernel::*;").unwrap();
-    }
-    writeln!(&mut out, "}}").unwrap();
-    writeln!(&mut out, "pub mod any {{").unwrap();
-    if userspace {
-        // If userspace, put the any-context functions in the root of the module
-        for syscall in syscalls.user.iter() {
-            writeln!(
-                &mut out,
-                "    pub use super::super::raw::z_anyctx_{} as {};",
-                syscall, syscall
-            )
-            .unwrap();
-        }
-    } else {
-        // Else, import all kernel functions since they can be called directly
-        writeln!(&mut out, "pub use super::kernel::*;").unwrap();
-    }
-    writeln!(&mut out, "}}").unwrap();
+    // This build.rs just invokes "cargo run" in a different project.  We do it this way to avoid
+    // having any build-dependencies in this project.  Cargo hopelessly conflates dependencies and
+    // build-dependencies in a way that makes it impossible to build libstd
+    let mut zb = std::path::PathBuf::new();
+    zb.push(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR unset"));
+    zb.push("zephyr-bindgen");
+    let rc = std::process::Command::new("cargo")
+        .args(&["run"])
+        .current_dir(zb)
+        .status()
+        .expect("cargo run failed");
+    assert!(rc.success());
 }

--- a/rust-app/zephyr-sys/zephyr-bindgen/Cargo.toml
+++ b/rust-app/zephyr-sys/zephyr-bindgen/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "zephyr-bindgen"
+version = "0.1.0"
+authors = ["Steven Walter <stevenrwalter@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bindgen = "0.49.0"

--- a/rust-app/zephyr-sys/zephyr-bindgen/src/main.rs
+++ b/rust-app/zephyr-sys/zephyr-bindgen/src/main.rs
@@ -1,0 +1,114 @@
+extern crate bindgen;
+
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use bindgen::callbacks::ParseCallbacks;
+
+#[derive(Debug, Default)]
+struct CallbacksInner {
+    /// k_impl_* real functions that bindgen picked up
+    kernel: Vec<String>,
+    /// z_anyctx_* definitions that we generate for every syscall
+    user: Vec<String>,
+}
+#[derive(Clone, Debug, Default)]
+struct Callbacks(Arc<Mutex<CallbacksInner>>);
+
+impl ParseCallbacks for Callbacks {
+    fn item_name(&self, name: &str) -> Option<String> {
+        const KERNEL: &str = "z_impl_";
+        const ANY: &str = "z_anyctx_";
+        let mut inner = self.0.lock().unwrap();
+        if name.starts_with(KERNEL) {
+            inner.kernel.push(name[KERNEL.len()..].into());
+        } else if name.starts_with(ANY) {
+            inner.user.push(name[ANY.len()..].into());
+        }
+        None
+    }
+}
+
+fn main() {
+    let flags = env::var("TARGET_CFLAGS").unwrap_or("".to_string());
+    eprintln!("cflags: {}", flags);
+    let userspace = env::var("CONFIG_USERSPACE").expect("CONFIG_USERSPACE must be set") == "y";
+    eprintln!("userspace: {}", userspace);
+
+    let callbacks = Callbacks::default().clone();
+    // The bindgen::Builder is the main entry point
+    // to bindgen, and lets you build up options for
+    // the resulting bindings.
+    let bindings = bindgen::Builder::default()
+        // The input header we would like to generate
+        // bindings for.
+        .header("wrapper.h")
+        .use_core()
+        .ctypes_prefix("super::ctypes")
+        .parse_callbacks(Box::new(callbacks.clone()))
+        // XXX: doesn't handle args with spaces in quotes
+        .clang_args(flags.split(" "))
+        .blacklist_item(".*x86_mmu.*")
+        .blacklist_item(".*x86_.*pdpt")
+        // Finish the builder and generate the bindings.
+        .generate()
+        // Unwrap the Result and panic on failure.
+        .expect("Unable to generate bindings");
+
+    // Write the bindings to the $OUT_DIR/bindings.rs file.
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("Couldn't write bindings!");
+
+    // Namespace aliases to syscalls by their valid contexts
+    let mut out = File::create(out_path.join("syscalls.rs")).unwrap();
+    let syscalls = callbacks.0.lock().unwrap();
+    writeln!(&mut out, "pub mod kernel {{").unwrap();
+    for syscall in syscalls.kernel.iter() {
+        if syscalls.user.iter().any(|c| c == syscall) {
+            writeln!(
+                &mut out,
+                "    pub use super::super::raw::z_impl_{} as {};",
+                syscall, syscall
+            )
+            .unwrap();
+        }
+    }
+    writeln!(&mut out, "}}").unwrap();
+    writeln!(&mut out, "pub mod user {{").unwrap();
+    if userspace {
+        // If userspace enabled, output each userspace-context syscall here
+        for syscall in syscalls.user.iter() {
+            writeln!(
+                &mut out,
+                "    pub use super::super::raw::z_userctx_{} as {};",
+                syscall, syscall
+            )
+            .unwrap();
+        }
+    } else {
+        // Else, import all the kernel functions since they can be called directly
+        writeln!(&mut out, "pub use super::kernel::*;").unwrap();
+    }
+    writeln!(&mut out, "}}").unwrap();
+    writeln!(&mut out, "pub mod any {{").unwrap();
+    if userspace {
+        // If userspace, put the any-context functions in the root of the module
+        for syscall in syscalls.user.iter() {
+            writeln!(
+                &mut out,
+                "    pub use super::super::raw::z_anyctx_{} as {};",
+                syscall, syscall
+            )
+            .unwrap();
+        }
+    } else {
+        // Else, import all kernel functions since they can be called directly
+        writeln!(&mut out, "pub use super::kernel::*;").unwrap();
+    }
+    writeln!(&mut out, "}}").unwrap();
+}


### PR DESCRIPTION
Make the implementation of zephyr-sys's build.rs be a separate cargo
project to avoid having any build-dependencies in zephyr-sys.  This is
to work around buggy behavior with cargo when build libstd