### PR TITLE
zephyr-bindgen: split build.rs into its own project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,17 @@ target_link_libraries(syscall_thunk zephyr_interface)
 # High level target that means all headers have been generated
 add_dependencies(syscall_thunk offsets_h)
 
+set(rust_src_dir ${CMAKE_CURRENT_SOURCE_DIR}/zephyr-bindgen)
+set(rust_build_dir ${CMAKE_CURRENT_BINARY_DIR}/zephyr-bindgen)
+set(zephyr_bindgen ${rust_build_dir}/release/zephyr-bindgen)
+
+add_custom_command(OUTPUT ${zephyr_bindgen}
+    WORKING_DIRECTORY ${rust_src_dir}
+    DEPENDS ${rust_syscall_macros_h}
+    COMMAND
+          cargo -v build --release --target-dir=${rust_build_dir}
+)
+
 set(rust_src_dir ${CMAKE_CURRENT_SOURCE_DIR}/rust-app)
 set(rust_build_dir ${CMAKE_CURRENT_BINARY_DIR}/rust-app)
 set(rust_staticlib ${rust_build_dir}/${rust_target}/release/librust_app.a)
@@ -46,9 +57,10 @@ set(external_project_cflags
 
 add_custom_command(OUTPUT ${rust_staticlib}
     WORKING_DIRECTORY ${rust_src_dir}
-    DEPENDS ${rust_syscall_macros_h}
+    DEPENDS ${rust_syscall_macros_h} ${zephyr_bindgen}
     COMMAND
           env
+          "ZEPHYR_BINDGEN=${zephyr_bindgen}"
           "CONFIG_USERSPACE=${CONFIG_USERSPACE}"
           "TARGET_CFLAGS=${external_project_cflags} --target=${clang_target}"
           "XARGO_HOME=${rust_build_dir}/xargo"

--- a/rust-app/zephyr-sys/Cargo.toml
+++ b/rust-app/zephyr-sys/Cargo.toml
@@ -5,6 +5,3 @@ authors = ["Tyler Hall <tylerwhall@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-
-[build-dependencies]
-bindgen = "0.49.0"

--- a/rust-app/zephyr-sys/build.rs
+++ b/rust-app/zephyr-sys/build.rs
@@ -1,114 +1,12 @@
-extern crate bindgen;
-
 use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
-
-use bindgen::callbacks::ParseCallbacks;
-
-#[derive(Debug, Default)]
-struct CallbacksInner {
-    /// k_impl_* real functions that bindgen picked up
-    kernel: Vec<String>,
-    /// z_anyctx_* definitions that we generate for every syscall
-    user: Vec<String>,
-}
-#[derive(Clone, Debug, Default)]
-struct Callbacks(Arc<Mutex<CallbacksInner>>);
-
-impl ParseCallbacks for Callbacks {
-    fn item_name(&self, name: &str) -> Option<String> {
-        const KERNEL: &str = "z_impl_";
-        const ANY: &str = "z_anyctx_";
-        let mut inner = self.0.lock().unwrap();
-        if name.starts_with(KERNEL) {
-            inner.kernel.push(name[KERNEL.len()..].into());
-        } else if name.starts_with(ANY) {
-            inner.user.push(name[ANY.len()..].into());
-        }
-        None
-    }
-}
 
 fn main() {
-    let flags = env::var("TARGET_CFLAGS").unwrap_or("".to_string());
-    eprintln!("cflags: {}", flags);
-    let userspace = env::var("CONFIG_USERSPACE").expect("CONFIG_USERSPACE must be set") == "y";
-    eprintln!("userspace: {}", userspace);
-
-    let callbacks = Callbacks::default().clone();
-    // The bindgen::Builder is the main entry point
-    // to bindgen, and lets you build up options for
-    // the resulting bindings.
-    let bindings = bindgen::Builder::default()
-        // The input header we would like to generate
-        // bindings for.
-        .header("wrapper.h")
-        .use_core()
-        .ctypes_prefix("super::ctypes")
-        .parse_callbacks(Box::new(callbacks.clone()))
-        // XXX: doesn't handle args with spaces in quotes
-        .clang_args(flags.split(" "))
-        .blacklist_item(".*x86_mmu.*")
-        .blacklist_item(".*x86_.*pdpt")
-        // Finish the builder and generate the bindings.
-        .generate()
-        // Unwrap the Result and panic on failure.
-        .expect("Unable to generate bindings");
-
-    // Write the bindings to the $OUT_DIR/bindings.rs file.
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-    bindings
-        .write_to_file(out_path.join("bindings.rs"))
-        .expect("Couldn't write bindings!");
-
-    // Namespace aliases to syscalls by their valid contexts
-    let mut out = File::create(out_path.join("syscalls.rs")).unwrap();
-    let syscalls = callbacks.0.lock().unwrap();
-    writeln!(&mut out, "pub mod kernel {{").unwrap();
-    for syscall in syscalls.kernel.iter() {
-        if syscalls.user.iter().any(|c| c == syscall) {
-            writeln!(
-                &mut out,
-                "    pub use super::super::raw::z_impl_{} as {};",
-                syscall, syscall
-            )
-            .unwrap();
-        }
-    }
-    writeln!(&mut out, "}}").unwrap();
-    writeln!(&mut out, "pub mod user {{").unwrap();
-    if userspace {
-        // If userspace enabled, output each userspace-context syscall here
-        for syscall in syscalls.user.iter() {
-            writeln!(
-                &mut out,
-                "    pub use super::super::raw::z_userctx_{} as {};",
-                syscall, syscall
-            )
-            .unwrap();
-        }
-    } else {
-        // Else, import all the kernel functions since they can be called directly
-        writeln!(&mut out, "pub use super::kernel::*;").unwrap();
-    }
-    writeln!(&mut out, "}}").unwrap();
-    writeln!(&mut out, "pub mod any {{").unwrap();
-    if userspace {
-        // If userspace, put the any-context functions in the root of the module
-        for syscall in syscalls.user.iter() {
-            writeln!(
-                &mut out,
-                "    pub use super::super::raw::z_anyctx_{} as {};",
-                syscall, syscall
-            )
-            .unwrap();
-        }
-    } else {
-        // Else, import all kernel functions since they can be called directly
-        writeln!(&mut out, "pub use super::kernel::*;").unwrap();
-    }
-    writeln!(&mut out, "}}").unwrap();
+    // This build.rs just invokes a binary from a different project.  We do it this way to avoid
+    // having any build-dependencies in this project.  Cargo hopelessly conflates dependencies and
+    // build-dependencies in a way that makes it impossible to build libstd
+    let zb = env::var("ZEPHYR_BINDGEN").expect("ZEPHYR_BINDGEN unset");
+    let rc = std::process::Command::new(zb)
+        .status()
+        .expect("cargo run failed");
+    assert!(rc.success());
 }

--- a/zephyr-bindgen/Cargo.toml
+++ b/zephyr-bindgen/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "zephyr-bindgen"
+version = "0.1.0"
+authors = ["Steven Walter <stevenrwalter@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bindgen = "0.49.0"

--- a/zephyr-bindgen/src/main.rs
+++ b/zephyr-bindgen/src/main.rs
@@ -1,0 +1,114 @@
+extern crate bindgen;
+
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use bindgen::callbacks::ParseCallbacks;
+
+#[derive(Debug, Default)]
+struct CallbacksInner {
+    /// k_impl_* real functions that bindgen picked up
+    kernel: Vec<String>,
+    /// z_anyctx_* definitions that we generate for every syscall
+    user: Vec<String>,
+}
+#[derive(Clone, Debug, Default)]
+struct Callbacks(Arc<Mutex<CallbacksInner>>);
+
+impl ParseCallbacks for Callbacks {
+    fn item_name(&self, name: &str) -> Option<String> {
+        const KERNEL: &str = "z_impl_";
+        const ANY: &str = "z_anyctx_";
+        let mut inner = self.0.lock().unwrap();
+        if name.starts_with(KERNEL) {
+            inner.kernel.push(name[KERNEL.len()..].into());
+        } else if name.starts_with(ANY) {
+            inner.user.push(name[ANY.len()..].into());
+        }
+        None
+    }
+}
+
+fn main() {
+    let flags = env::var("TARGET_CFLAGS").unwrap_or("".to_string());
+    eprintln!("cflags: {}", flags);
+    let userspace = env::var("CONFIG_USERSPACE").expect("CONFIG_USERSPACE must be set") == "y";
+    eprintln!("userspace: {}", userspace);
+
+    let callbacks = Callbacks::default().clone();
+    // The bindgen::Builder is the main entry point
+    // to bindgen, and lets you build up options for
+    // the resulting bindings.
+    let bindings = bindgen::Builder::default()
+        // The input header we would like to generate
+        // bindings for.
+        .header("wrapper.h")
+        .use_core()
+        .ctypes_prefix("super::ctypes")
+        .parse_callbacks(Box::new(callbacks.clone()))
+        // XXX: doesn't handle args with spaces in quotes
+        .clang_args(flags.split(" "))
+        .blacklist_item(".*x86_mmu.*")
+        .blacklist_item(".*x86_.*pdpt")
+        // Finish the builder and generate the bindings.
+        .generate()
+        // Unwrap the Result and panic on failure.
+        .expect("Unable to generate bindings");
+
+    // Write the bindings to the $OUT_DIR/bindings.rs file.
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("Couldn't write bindings!");
+
+    // Namespace aliases to syscalls by their valid contexts
+    let mut out = File::create(out_path.join("syscalls.rs")).unwrap();
+    let syscalls = callbacks.0.lock().unwrap();
+    writeln!(&mut out, "pub mod kernel {{").unwrap();
+    for syscall in syscalls.kernel.iter() {
+        if syscalls.user.iter().any(|c| c == syscall) {
+            writeln!(
+                &mut out,
+                "    pub use super::super::raw::z_impl_{} as {};",
+                syscall, syscall
+            )
+            .unwrap();
+        }
+    }
+    writeln!(&mut out, "}}").unwrap();
+    writeln!(&mut out, "pub mod user {{").unwrap();
+    if userspace {
+        // If userspace enabled, output each userspace-context syscall here
+        for syscall in syscalls.user.iter() {
+            writeln!(
+                &mut out,
+                "    pub use super::super::raw::z_userctx_{} as {};",
+                syscall, syscall
+            )
+            .unwrap();
+        }
+    } else {
+        // Else, import all the kernel functions since they can be called directly
+        writeln!(&mut out, "pub use super::kernel::*;").unwrap();
+    }
+    writeln!(&mut out, "}}").unwrap();
+    writeln!(&mut out, "pub mod any {{").unwrap();
+    if userspace {
+        // If userspace, put the any-context functions in the root of the module
+        for syscall in syscalls.user.iter() {
+            writeln!(
+                &mut out,
+                "    pub use super::super::raw::z_anyctx_{} as {};",
+                syscall, syscall
+            )
+            .unwrap();
+        }
+    } else {
+        // Else, import all kernel functions since they can be called directly
+        writeln!(&mut out, "pub use super::kernel::*;").unwrap();
+    }
+    writeln!(&mut out, "}}").unwrap();
+}


### PR DESCRIPTION
Make the implementation of zephyr-sys's build.rs be a separate cargo
project to avoid having any build-dependencies in zephyr-sys.  This is
to work around buggy behavior with cargo when build libstd