### PR TITLE
zephyr-core: clock_gettime is now a syscall

### DIFF
--- a/rust/zephyr-core/src/lib.rs
+++ b/rust/zephyr-core/src/lib.rs
@@ -16,9 +16,6 @@ mod time;
 
 pub use time::*;
 
-#[cfg(clock)]
-use core::mem;
-
 // Set from environment from build.rs
 pub const CONFIG_USERSPACE: bool = cfg!(usermode);
 
@@ -85,6 +82,22 @@ macro_rules! zephyr_bindings {
         #[inline(always)]
         pub fn k_thread_custom_data_set(value: *mut u8) {
             unsafe { zephyr_sys::syscalls::$context::k_thread_custom_data_set(value as *mut _) };
+        }
+
+        #[cfg(clock)]
+        #[inline(always)]
+        pub fn clock_settime(timespec: zephyr_sys::raw::timespec) {
+            unsafe { zephyr_sys::raw::clock_settime(zephyr_sys::raw::CLOCK_REALTIME, &timespec); }
+        }
+
+        #[cfg(clock)]
+        #[inline(always)]
+        pub fn clock_gettime() -> zephyr_sys::raw::timespec {
+            unsafe {
+                let mut t: zephyr_sys::raw::timespec = core::mem::zeroed();
+                zephyr_sys::syscalls::$context::clock_gettime(zephyr_sys::raw::CLOCK_REALTIME, &mut t);
+                t
+            }
         }
 
         impl crate::mutex::MutexSyscalls for $context_struct {
@@ -178,18 +191,4 @@ pub mod user {
 
 pub mod any {
     zephyr_bindings!(any, crate::context::Any);
-}
-
-#[cfg(clock)]
-pub fn clock_settime(timespec: zephyr_sys::raw::timespec) {
-    unsafe { zephyr_sys::raw::clock_settime(zephyr_sys::raw::CLOCK_REALTIME, &timespec); }
-}
-
-#[cfg(clock)]
-pub fn clock_gettime() -> zephyr_sys::raw::timespec {
-    unsafe {
-        let mut t: zephyr_sys::raw::timespec = mem::zeroed();
-        zephyr_sys::raw::clock_gettime(zephyr_sys::raw::CLOCK_REALTIME, &mut t);
-        t
-    }
 }

--- a/scripts/gen_syscalls.py
+++ b/scripts/gen_syscalls.py
@@ -139,8 +139,8 @@ def main():
     # Whitelist syscall groups for which to generate bindings. The syscall
     # headers are not self-sufficient, so we have to manually list the other
     # headers they need for their argument types.
-    whitelist = set(["kernel.h", "device.h", "uart.h", "mutex.h", "errno_private.h", "eeprom.h"])
-    includes = ["kernel.h", "device.h", "drivers/uart.h", "sys/mutex.h", "drivers/eeprom.h"]
+    whitelist = set(["kernel.h", "device.h", "uart.h", "mutex.h", "errno_private.h", "eeprom.h", "time.h"])
+    includes = ["kernel.h", "device.h", "drivers/uart.h", "sys/mutex.h", "drivers/eeprom.h", "posix/time.h"]
     for match_group, fn in syscalls:
         if fn not in whitelist:
             continue


### PR DESCRIPTION
clock_gettime() has been changed to a syscall in the latest zephyr.