### PR TITLE
Syscalls: Add Fix for Zephyr v2.7

### DIFF
--- a/rust/zephyr-core/build.rs
+++ b/rust/zephyr-core/build.rs
@@ -9,6 +9,10 @@ fn main() {
         println!("cargo:rustc-cfg=zephyr250");
     }
 
+    if kernel_version >= 0x2_07_00 {
+        println!("cargo:rustc-cfg=zephyr270");
+    }
+
     if std::env::var("CONFIG_USERSPACE").expect("CONFIG_USERSPACE must be set") == "y" {
         println!("cargo:rustc-cfg=usermode");
     }
@@ -20,5 +24,10 @@ fn main() {
     }
     if std::env::var("CONFIG_POSIX_CLOCK").expect("CONFIG_POSIX_CLOCK must be set") == "y" {
         println!("cargo:rustc-cfg=clock");
+    }
+    if let Ok(tls) = std::env::var("CONFIG_THREAD_LOCAL_STORAGE") {
+        if tls == "y" {
+            println!("cargo:rustc-cfg=tls");
+        }
     }
 }

--- a/rust/zephyr-core/src/thread.rs
+++ b/rust/zephyr-core/src/thread.rs
@@ -32,9 +32,28 @@ macro_rules! trait_impl {
                 unsafe { zephyr_sys::syscalls::$context::k_wakeup(thread.tid()) }
             }
 
+            #[cfg(not(zephyr270))]
             fn k_current_get() -> crate::thread::ThreadId {
                 ThreadId(unsafe {
                     NonNull::new_unchecked(zephyr_sys::syscalls::$context::k_current_get())
+                })
+            }
+
+            #[cfg(all(zephyr270, tls))]
+            fn k_current_get() -> crate::thread::ThreadId {
+                extern "C" {
+                    #[no_mangle]
+                    static z_tls_current: *mut zephyr_sys::raw::k_thread;
+                }
+                ThreadId(unsafe {
+                    NonNull::new_unchecked(z_tls_current)
+                })
+            }
+
+            #[cfg(all(zephyr270, not(tls)))]
+            fn k_current_get() -> crate::thread::ThreadId {
+                ThreadId(unsafe {
+                    NonNull::new_unchecked(zephyr_sys::syscalls::$context::z_current_get())
                 })
             }
 


### PR DESCRIPTION
In Zephyr version 2.7 the following syscall

```
/**
 * @brief Get thread ID of the current thread.
 *
 * @return ID of current thread.
 *
 */
__syscall k_tid_t k_current_get(void) __attribute_const__;
```

was changed to this

```
/**
 * @brief Get thread ID of the current thread.
 *
 * This unconditionally queries the kernel via a system call.
 *
 * @return ID of current thread.
 */
__attribute_const__
__syscall k_tid_t z_current_get(void);

#ifdef CONFIG_THREAD_LOCAL_STORAGE
/* Thread-local cache of current thread ID, set in z_thread_entry() */
extern __thread k_tid_t z_tls_current;
#endif

/**
 * @brief Get thread ID of the current thread.
 *
 * @return ID of current thread.
 *
 */
__attribute_const__
static inline k_tid_t k_current_get(void)
{
#ifdef CONFIG_THREAD_LOCAL_STORAGE
	return z_tls_current;
#else
	return z_current_get();
#endif
}
```

This PR fixes the syscall so that the rust-app example can compile with zephyr v2.7