### PR TITLE
Add support for Zephyr >= 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ add_custom_command(OUTPUT ${all_syscalls} ${syscall_thunks}
           ${CMAKE_CURRENT_SOURCE_DIR}/scripts/gen_syscalls.py
   )
 add_custom_target(syscall_thunks_target DEPENDS
-                  ${all_syscalls} ${syscall_thunks} ${SYSCALL_LIST_H_TARGET})
+        ${all_syscalls} ${syscall_thunks} ${SYSCALL_LIST_H_TARGET} kernel)
 
 if(NOT ZEPHYR_BINDGEN)
     set(zephyr_bindgen_src_dir ${CMAKE_CURRENT_SOURCE_DIR}/zephyr-bindgen)

--- a/abort.c
+++ b/abort.c
@@ -5,7 +5,12 @@
  */
 
 #include <stdlib.h>
+#include <version.h>
+#if KERNEL_VERSION_MAJOR < 3
 #include <zephyr.h>
+#else
+#include <zephyr/kernel.h>
+#endif
 
 #if KERNEL_VERSION_MAJOR <= 2 && KERNEL_VERSION_MINOR < 5
 void __attribute__((weak, noreturn)) abort(void)

--- a/mutex-pool/gen-mutex-pool.py
+++ b/mutex-pool/gen-mutex-pool.py
@@ -7,9 +7,18 @@ count = int(sys.argv[1])
 initializer = "\n".join([f'\tZ_MUTEX_INITIALIZER(rust_mutex_pool[{i}]),' for i in range(count)])
 
 sys.stdout.write(f'''
+#include <version.h>
+#if KERNEL_VERSION_MAJOR < 3
 #include <kernel.h>
+#else
+#include <zephyr/kernel.h>
+#endif
 
+#if KERNEL_VERSION_MAJOR < 3
 Z_STRUCT_SECTION_ITERABLE(k_mutex, rust_mutex_pool[{count}]) = {{
+#else
+STRUCT_SECTION_ITERABLE(k_mutex, rust_mutex_pool[{count}]) = {{
+#endif
 {initializer}
 }};
 ''')

--- a/rust-smem.c
+++ b/rust-smem.c
@@ -1,7 +1,13 @@
+#include <version.h>
+#if KERNEL_VERSION_MAJOR < 3
 #include <zephyr.h>
 #include <init.h>
-#include <version.h>
 #include <app_memory/app_memdomain.h>
+#else
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/app_memory/app_memdomain.h>
+#endif
 
 #ifdef CONFIG_USERSPACE
 struct k_mem_domain rust_std_domain;

--- a/rust/zephyr-core/build.rs
+++ b/rust/zephyr-core/build.rs
@@ -5,6 +5,9 @@ fn main() {
     let kernel_version = u32::from_str_radix(&kernel_version_str_trimmed, 16)
         .expect("ZEPHYR_KERNEL_VERSION_NUM must be an integer");
 
+    if kernel_version >= 0x3_00_00 {
+        println!("cargo:rustc-cfg=zephyr300");
+    }
     if kernel_version >= 0x2_05_00 {
         println!("cargo:rustc-cfg=zephyr250");
     }

--- a/rust/zephyr-core/src/memdomain.rs
+++ b/rust/zephyr-core/src/memdomain.rs
@@ -33,7 +33,7 @@ pub trait MemDomainAPI {
 impl MemDomainAPI for crate::context::Kernel {
     fn k_mem_domain_add_thread(domain: &k_mem_domain, thread: ThreadId) {
         unsafe {
-            zephyr_sys::raw::k_mem_domain_add_thread(domain as *const _ as *mut _, thread.tid())
+            zephyr_sys::raw::k_mem_domain_add_thread(domain as *const _ as *mut _, thread.tid());
         }
     }
 }

--- a/rust/zephyr-core/src/thread.rs
+++ b/rust/zephyr-core/src/thread.rs
@@ -32,7 +32,7 @@ macro_rules! trait_impl {
                 unsafe { zephyr_sys::syscalls::$context::k_wakeup(thread.tid()) }
             }
 
-            #[cfg(not(zephyr270))]
+            #[cfg(not(any(zephyr270, zephyr300)))]
             fn k_current_get() -> crate::thread::ThreadId {
                 ThreadId(unsafe {
                     NonNull::new_unchecked(zephyr_sys::syscalls::$context::k_current_get())
@@ -50,7 +50,7 @@ macro_rules! trait_impl {
                 })
             }
 
-            #[cfg(all(zephyr270, not(tls)))]
+            #[cfg(any(zephyr300, all(zephyr270, not(tls))))]
             fn k_current_get() -> crate::thread::ThreadId {
                 ThreadId(unsafe {
                     NonNull::new_unchecked(zephyr_sys::syscalls::$context::z_current_get())

--- a/rust/zephyr-sys/wrapper.h
+++ b/rust/zephyr-sys/wrapper.h
@@ -2,13 +2,22 @@
 // defined
 #define _GCC_MAX_ALIGN_T
 
+#include <version.h>
+#if KERNEL_VERSION_MAJOR < 3
 #include <kernel.h>
 #include <all_syscalls.h>
-#include <version.h>
 #include <device.h>
 #include <drivers/uart.h>
 #include <uart_buffered.h>
 #include <drivers/eeprom.h>
+#else
+#include <zephyr/kernel.h>
+#include <all_syscalls.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/uart.h>
+#include <uart_buffered.h>
+#include <zephyr/drivers/eeprom.h>
+#endif
 
 #ifdef CONFIG_POSIX_CLOCK
 #include <posix/time.h>

--- a/samples/rust-app/src/main.c
+++ b/samples/rust-app/src/main.c
@@ -1,4 +1,9 @@
+#include <version.h>
+#if KERNEL_VERSION_MAJOR < 3
 #include <zephyr.h>
+#else
+#include <zephyr/kernel.h>
+#endif
 
 #define MY_STACK_SIZE 1024
 #define MY_PRIORITY 5

--- a/scripts/gen_syscalls.py
+++ b/scripts/gen_syscalls.py
@@ -147,9 +147,6 @@ def main():
     whitelist = set(["kernel.h", "kobject.h", "device.h", "uart.h", "mutex.h", "errno_private.h", "eeprom.h", "time.h"])
     includes = ["kernel.h", "device.h", "drivers/uart.h", "sys/mutex.h", "sys/errno_private.h", "drivers/eeprom.h", "posix/time.h"]
 
-    # Hack because z_sys_mutex_kernel_lock is not defined in sys/mutex.h for !USERSPACE
-    includes.append("syscalls/mutex.h")
-
     for match_group, fn in syscalls:
         if fn not in whitelist:
             continue
@@ -161,11 +158,19 @@ def main():
     os.makedirs(os.path.dirname(args.thunks), exist_ok=True)
     os.makedirs(os.path.dirname(args.all_syscalls), exist_ok=True)
 
-    includes = ["#include <%s>" % fn for fn in includes]
     with open(args.all_syscalls, "w") as fp:
         fp.write("#ifndef ZEPHYR_ALL_SYSCALLS_H\n")
         fp.write("#define ZEPHYR_ALL_SYSCALLS_H\n")
-        fp.write("\n".join(includes))
+        fp.write("#include <version.h>\n")
+        fp.write("#if KERNEL_VERSION_MAJOR < 3\n")
+        fp.write("\n".join(["#include <%s>" % fn for fn in includes]))
+        fp.write("\n#else\n")
+        fp.write("\n".join(["#include <zephyr/%s>" % fn for fn in includes]))
+        fp.write("\n#endif\n")
+        fp.write("\n")
+        # Hack because z_sys_mutex_kernel_lock is not defined in sys/mutex.h for !USERSPACE
+        # This is the same on all zephyr versions as it exists in include/generated
+        fp.write("#include <syscalls/mutex.h>\n")
         fp.write("\n")
         fp.write("".join(declarations))
         fp.write("\n#endif\n")

--- a/uart-buffered/src/uart_buffered.h
+++ b/uart-buffered/src/uart_buffered.h
@@ -1,8 +1,13 @@
 #ifndef __UART_BUFFERED_H__
 #define __UART_BUFFERED_H__
 
+#include <version.h>
+#if KERNEL_VERSION_MAJOR < 3
 #include <zephyr.h>
 #include <kernel.h>
+#else
+#include <zephyr/kernel.h>
+#endif
 
 typedef uint16_t fifo_index_t;
 struct fifo {


### PR DESCRIPTION
Zephyr 3 renames many of the import paths, but this is fairly easy to solve with a `#if` check.