### PR TITLE
Add missing code-model argument for riscv64 targets.

### DIFF
--- a/rust/riscv64imac-unknown-zephyr-elf.json
+++ b/rust/riscv64imac-unknown-zephyr-elf.json
@@ -8,6 +8,7 @@
     "sysv64"
   ],
   "arch": "riscv64",
+  "code-model": "medium",
   "data-layout": "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128",
   "emit-debug-gdb-scripts": false,
   "env": "gnu",


### PR DESCRIPTION
By default, rust uses a code model of `medany` on riscv targets. RV64 requires `medium` as per [riscv64imac_unknown_none_elf.rs](https://github.com/rust-lang/rust/blob/c65ffa789d57004db42f6c30405c59e0a5bae330/src/librustc_target/spec/riscv64imac_unknown_none_elf.rs#L26)

Resolves issue with `qemu_riscv64` discussed in #35.