### PR TITLE
fix gen_syscalls.py for zephyr 3.4

### DIFF
--- a/scripts/gen_syscalls.py
+++ b/scripts/gen_syscalls.py
@@ -147,7 +147,7 @@ def main():
     whitelist = set(["kernel.h", "kobject.h", "device.h", "uart.h", "mutex.h", "errno_private.h", "eeprom.h", "time.h"])
     includes = ["kernel.h", "device.h", "drivers/uart.h", "sys/mutex.h", "sys/errno_private.h", "drivers/eeprom.h", "posix/time.h"]
 
-    for match_group, fn in syscalls:
+    for match_group, fn, to_emit in syscalls:
         if fn not in whitelist:
             continue
         include = "syscalls/%s" % fn


### PR DESCRIPTION
Output generated from `parse_syscalls.py` in zephyr 3.4.99 ( from nRF Connect SDK )
```
syscalls:  [[['int zephyr_read_stdin', 'char *buf, int nbytes'], 'libc-hooks.h', True], [['int zephyr_write_stdout', 'const void *buf, int nbytes'], 'libc-hooks.h', True], [['int zephyr_fputc', 'int c, FILE * stream'], 'libc-hooks.h', True], [['size_t zephyr_fwrite', 'const void *ZRESTRICT ptr, size_t size,\n\t\t\t\tsize_t nitems, FILE *ZRESTRICT stream'], 'libc-hooks.h', True], [['int clock_gettime', 'clockid_t clock_id, struct timespec *ts'], 'time.h', True], [['int z_sys_mutex_kernel_lock', 'struct sys_mutex *mutex,\n\t\t\t\t      k_timeout_t timeout'], 'mutex.h', True], [['int z_sys_mutex_kernel_unlock', 'struct sys_mutex *mutex'], 'mutex.h', True], [['void z_log_msg_static_create', 'const void *source,\n\t\t\t\t\tconst struct log_msg_desc desc,\n\t\t\t\t\tuint8_t *package, const void *data'], 'log_msg.h', True], [['void z_log_msg_runtime_vcreate', 'uint8_t domain_id, const void *source,\n\t\t\t\t\t  uint8_t level, const void *data,\n\t\t\t\t\t  size_t dlen, uint32_t package_flags,\n\t\t\t\t\t  const char *fmt,\n\t\t\t\t\t  va_list ap'], 'log_msg.h', True], [['void log_panic', 'void'], 'log_ctrl.h', True], [['bool log_process', 'void'], 'log_ctrl.h', True], [['uint32_t log_buffered_cnt', 'void'], 'log_ctrl.h', True], [['uint32_t log_filter_set', 'struct log_backend const *const backend,\n\t\t\t\t  uint32_t domain_id, int16_t source_id,\n\t\t\t\t  uint32_t level'], 'log_ctrl.h', True], [['uint32_t sys_rand32_get', 'void'], 'rand32.h', True], [['void sys_rand_get', 'void *dst, size_t len'], 'rand32.h', True], [['int sys_csrand_get', 'void *dst, size_t len'], 'rand32.h', True], [['int uart_err_check', 'const struct device *dev'], 'uart.h', True], [['int uart_poll_in', 'const struct device *dev, unsigned char *p_char'], 'uart.h', True], [['int uart_poll_in_u16', 'const struct device *dev, uint16_t *p_u16'], 'uart.h', True], [['void uart_poll_out', 'const struct device *dev,\n\t\t\t     unsigned char out_char'], 'uart.h', True], [['void uart_poll_out_u16', 'const struct device *dev, uint16_t out_u16'], 'uart.h', True], [['int uart_configure', 'const struct device *dev,\n\t\t\t     const struct uart_config *cfg'], 'uart.h', True], [['int uart_config_get', 'const struct device *dev,\n\t\t\t      struct uart_config *cfg'], 'uart.h', True], [['void uart_irq_tx_enable', 'const struct device *dev'], 'uart.h', True], [['void uart_irq_tx_disable', 'const struct device *dev'], 'uart.h', True], [['void uart_irq_rx_enable', 'const struct device *dev'], 'uart.h', True], [['void uart_irq_rx_disable', 'const struct device *dev'], 'uart.h', True], [['void uart_irq_err_enable', 'const struct device *dev'], 'uart.h', True], [['void uart_irq_err_disable', 'const struct device *dev'], 'uart.h', True], [['int uart_irq_is_pending', 'const struct device *dev'], 'uart.h', True], [['int uart_irq_update', 'const struct device *dev'], 'uart.h', True], [['int uart_tx', 'const struct device *dev, const uint8_t *buf,\n\t\t      size_t len,\n\t\t      int32_t timeout'], 'uart.h', True], [['int uart_tx_u16', 'const struct device *dev, const uint16_t *buf,\n\t\t\t  size_t len, int32_t timeout'], 'uart.h', True], [['int uart_tx_abort', 'const struct device *dev'], 'uart.h', True], [['int uart_rx_enable', 'const struct device *dev, uint8_t *buf,\n\t\t\t     size_t len,\n\t\t\t     int32_t timeout'], 'uart.h', True], [['int uart_rx_enable_u16', 'const struct device *dev, uint16_t *buf,\n\t\t\t\t size_t len, int32_t timeout'], 'uart.h', True], [['int uart_rx_disable', 'const struct device *dev'], 'uart.h', True], [['int uart_line_ctrl_set', 'const struct device *dev,\n\t\t\t\t uint32_t ctrl, uint32_t val'], 'uart.h', True], [['int uart_line_ctrl_get', 'const struct device *dev, uint32_t ctrl,\n\t\t\t\t uint32_t *val'], 'uart.h', True], [['int uart_drv_cmd', 'const struct device *dev, uint32_t cmd, uint32_t p'], 'uart.h', True], [['const struct device *device_get_binding', 'const char *name'], 'device.h', True], [['bool device_is_ready', 'const struct device *dev'], 'device.h', True], [['k_thread_stack_t *k_thread_stack_alloc', 'size_t size, int flags'], 'kernel.h', True], [['int k_thread_stack_free', 'k_thread_stack_t *stack'], 'kernel.h', True], [['k_tid_t k_thread_create', 'struct k_thread *new_thread,\n\t\t\t\t  k_thread_stack_t *stack,\n\t\t\t\t  size_t stack_size,\n\t\t\t\t  k_thread_entry_t entry,\n\t\t\t\t  void *p1, void *p2, void *p3,\n\t\t\t\t  int prio, uint32_t options, k_timeout_t delay'], 'kernel.h', True], [['int k_thread_stack_space_get', 'const struct k_thread *thread,\n\t\t\t\t       size_t *unused_ptr'], 'kernel.h', True], [['int k_thread_join', 'struct k_thread *thread, k_timeout_t timeout'], 'kernel.h', True], [['int32_t k_sleep', 'k_timeout_t timeout'], 'kernel.h', True], [['int32_t k_usleep', 'int32_t us'], 'kernel.h', True], [['void k_busy_wait', 'uint32_t usec_to_wait'], 'kernel.h', True], [['void k_yield', 'void'], 'kernel.h', True], [['void k_wakeup', 'k_tid_t thread'], 'kernel.h', True], [['k_tid_t z_current_get', 'void'], 'kernel.h', True], [['void k_thread_abort', 'k_tid_t thread'], 'kernel.h', True], [['void k_thread_start', 'k_tid_t thread'], 'kernel.h', True], [['k_ticks_t k_thread_timeout_expires_ticks', 'const struct k_thread *t'], 'kernel.h', True], [['k_ticks_t k_thread_timeout_remaining_ticks', 'const struct k_thread *t'], 'kernel.h', True], [['int k_thread_priority_get', 'k_tid_t thread'], 'kernel.h', True], [['void k_thread_priority_set', 'k_tid_t thread, int prio'], 'kernel.h', True], [['void k_thread_deadline_set', 'k_tid_t thread, int deadline'], 'kernel.h', True], [['void k_thread_suspend', 'k_tid_t thread'], 'kernel.h', True], [['void k_thread_resume', 'k_tid_t thread'], 'kernel.h', True], [['int k_is_preempt_thread', 'void'], 'kernel.h', True], [['void k_thread_custom_data_set', 'void *value'], 'kernel.h', True], [['void *k_thread_custom_data_get', 'void'], 'kernel.h', True], [['int k_thread_name_set', 'k_tid_t thread, const char *str'], 'kernel.h', True], [['int k_thread_name_copy', 'k_tid_t thread, char *buf,\n\t\t\t\t size_t size'], 'kernel.h', True], [['void k_timer_start', 'struct k_timer *timer,\n\t\t\t     k_timeout_t duration, k_timeout_t period'], 'kernel.h', True], [['void k_timer_stop', 'struct k_timer *timer'], 'kernel.h', True], [['uint32_t k_timer_status_get', 'struct k_timer *timer'], 'kernel.h', True], [['uint32_t k_timer_status_sync', 'struct k_timer *timer'], 'kernel.h', True], [['k_ticks_t k_timer_expires_ticks', 'const struct k_timer *timer'], 'kernel.h', True], [['k_ticks_t k_timer_remaining_ticks', 'const struct k_timer *timer'], 'kernel.h', True], [['void k_timer_user_data_set', 'struct k_timer *timer, void *user_data'], 'kernel.h', True], [['void *k_timer_user_data_get', 'const struct k_timer *timer'], 'kernel.h', True], [['int64_t k_uptime_ticks', 'void'], 'kernel.h', True], [['void k_queue_init', 'struct k_queue *queue'], 'kernel.h', True], [['void k_queue_cancel_wait', 'struct k_queue *queue'], 'kernel.h', True], [['int32_t k_queue_alloc_append', 'struct k_queue *queue, void *data'], 'kernel.h', True], [['int32_t k_queue_alloc_prepend', 'struct k_queue *queue, void *data'], 'kernel.h', True], [['void *k_queue_get', 'struct k_queue *queue, k_timeout_t timeout'], 'kernel.h', True], [['int k_queue_is_empty', 'struct k_queue *queue'], 'kernel.h', True], [['void *k_queue_peek_head', 'struct k_queue *queue'], 'kernel.h', True], [['void *k_queue_peek_tail', 'struct k_queue *queue'], 'kernel.h', True], [['int k_futex_wait', 'struct k_futex *futex, int expected,\n\t\t\t   k_timeout_t timeout'], 'kernel.h', True], [['int k_futex_wake', 'struct k_futex *futex, bool wake_all'], 'kernel.h', True], [['void k_event_init', 'struct k_event *event'], 'kernel.h', True], [['uint32_t k_event_post', 'struct k_event *event, uint32_t events'], 'kernel.h', True], [['uint32_t k_event_set', 'struct k_event *event, uint32_t events'], 'kernel.h', True], [['uint32_t k_event_set_masked', 'struct k_event *event, uint32_t events,\n\t\t\t\t  uint32_t events_mask'], 'kernel.h', True], [['uint32_t k_event_clear', 'struct k_event *event, uint32_t events'], 'kernel.h', True], [['uint32_t k_event_wait', 'struct k_event *event, uint32_t events,\n\t\t\t\tbool reset, k_timeout_t timeout'], 'kernel.h', True], [['uint32_t k_event_wait_all', 'struct k_event *event, uint32_t events,\n\t\t\t\t    bool reset, k_timeout_t timeout'], 'kernel.h', True], [['int32_t k_stack_alloc_init', 'struct k_stack *stack,\n\t\t\t\t   uint32_t num_entries'], 'kernel.h', True], [['int k_stack_push', 'struct k_stack *stack, stack_data_t data'], 'kernel.h', True], [['int k_stack_pop', 'struct k_stack *stack, stack_data_t *data,\n\t\t\t  k_timeout_t timeout'], 'kernel.h', True], [['int k_mutex_init', 'struct k_mutex *mutex'], 'kernel.h', True], [['int k_mutex_lock', 'struct k_mutex *mutex, k_timeout_t timeout'], 'kernel.h', True], [['int k_mutex_unlock', 'struct k_mutex *mutex'], 'kernel.h', True], [['int k_condvar_init', 'struct k_condvar *condvar'], 'kernel.h', True], [['int k_condvar_signal', 'struct k_condvar *condvar'], 'kernel.h', True], [['int k_condvar_broadcast', 'struct k_condvar *condvar'], 'kernel.h', True], [['int k_condvar_wait', 'struct k_condvar *condvar, struct k_mutex *mutex,\n\t\t\t     k_timeout_t timeout'], 'kernel.h', True], [['int k_sem_init', 'struct k_sem *sem, unsigned int initial_count,\n\t\t\t  unsigned int limit'], 'kernel.h', True], [['int k_sem_take', 'struct k_sem *sem, k_timeout_t timeout'], 'kernel.h', True], [['void k_sem_give', 'struct k_sem *sem'], 'kernel.h', True], [['void k_sem_reset', 'struct k_sem *sem'], 'kernel.h', True], [['unsigned int k_sem_count_get', 'struct k_sem *sem'], 'kernel.h', True], [['int k_msgq_alloc_init', 'struct k_msgq *msgq, size_t msg_size,\n\t\t\t\tuint32_t max_msgs'], 'kernel.h', True], [['int k_msgq_put', 'struct k_msgq *msgq, const void *data, k_timeout_t timeout'], 'kernel.h', True], [['int k_msgq_get', 'struct k_msgq *msgq, void *data, k_timeout_t timeout'], 'kernel.h', True], [['int k_msgq_peek', 'struct k_msgq *msgq, void *data'], 'kernel.h', True], [['int k_msgq_peek_at', 'struct k_msgq *msgq, void *data, uint32_t idx'], 'kernel.h', True], [['void k_msgq_purge', 'struct k_msgq *msgq'], 'kernel.h', True], [['uint32_t k_msgq_num_free_get', 'struct k_msgq *msgq'], 'kernel.h', True], [['void  k_msgq_get_attrs', 'struct k_msgq *msgq,\n\t\t\t\t struct k_msgq_attrs *attrs'], 'kernel.h', True], [['uint32_t k_msgq_num_used_get', 'struct k_msgq *msgq'], 'kernel.h', True], [['int k_pipe_alloc_init', 'struct k_pipe *pipe, size_t size'], 'kernel.h', True], [['int k_pipe_put', 'struct k_pipe *pipe, void *data,\n\t\t\t size_t bytes_to_write, size_t *bytes_written,\n\t\t\t size_t min_xfer, k_timeout_t timeout'], 'kernel.h', True], [['int k_pipe_get', 'struct k_pipe *pipe, void *data,\n\t\t\t size_t bytes_to_read, size_t *bytes_read,\n\t\t\t size_t min_xfer, k_timeout_t timeout'], 'kernel.h', True], [['size_t k_pipe_read_avail', 'struct k_pipe *pipe'], 'kernel.h', True], [['size_t k_pipe_write_avail', 'struct k_pipe *pipe'], 'kernel.h', True], [['void k_pipe_flush', 'struct k_pipe *pipe'], 'kernel.h', True], [['void k_pipe_buffer_flush', 'struct k_pipe *pipe'], 'kernel.h', True], [['int k_poll', 'struct k_poll_event *events, int num_events,\n\t\t     k_timeout_t timeout'], 'kernel.h', True], [['void k_poll_signal_init', 'struct k_poll_signal *sig'], 'kernel.h', True], [['void k_poll_signal_reset', 'struct k_poll_signal *sig'], 'kernel.h', True], [['void k_poll_signal_check', 'struct k_poll_signal *sig,\n\t\t\t\t   unsigned int *signaled, int *result'], 'kernel.h', True], [['int k_poll_signal_raise', 'struct k_poll_signal *sig, int result'], 'kernel.h', True], [['void k_str_out', 'char *c, size_t n'], 'kernel.h', True], [['int k_float_disable', 'struct k_thread *thread'], 'kernel.h', True], [['int k_float_enable', 'struct k_thread *thread, unsigned int options'], 'kernel.h', True], [['void k_object_access_grant', 'const void *object,\n\t\t\t\t     struct k_thread *thread'], 'kobject.h', True], [['void k_object_release', 'const void *object'], 'kobject.h', True], [['void *k_object_alloc', 'enum k_objects otype'], 'kobject.h', True], [['void *k_object_alloc_size', 'enum k_objects otype, size_t size'], 'kobject.h', True], [['int sys_clock_hw_cycles_per_sec_runtime_get', 'void'], 'time_units.h', True], [['void k_mem_paging_stats_get', 'struct k_mem_paging_stats_t *stats'], 'mem_manage.h', True], [['void k_mem_paging_thread_stats_get', 'struct k_thread *thread,\n\t\t\t\t   struct k_mem_paging_stats_t *stats'], 'mem_manage.h', True], [['void k_mem_paging_histogram_eviction_get', '\n\tstruct k_mem_paging_histogram_t *hist'], 'mem_manage.h', True], [['void k_mem_paging_histogram_backing_store_page_in_get', '\n\tstruct k_mem_paging_histogram_t *hist'], 'mem_manage.h', True], [['void k_mem_paging_histogram_backing_store_page_out_get', '\n\tstruct k_mem_paging_histogram_t *hist'], 'mem_manage.h', True], [['int sys_cache_data_flush_range', 'void *addr, size_t size'], 'cache.h', False], [['int sys_cache_data_invd_range', 'void *addr, size_t size'], 'cache.h', False], [['int sys_cache_data_flush_and_invd_range', 'void *addr, size_t size'], 'cache.h', False], [['void user_fault', 'unsigned int reason'], 'error.h', False], [['int adc_channel_setup', 'const struct device *dev,\n\t\t\t\tconst struct adc_channel_cfg *channel_cfg'], 'adc.h', False], [['int adc_read', 'const struct device *dev,\n\t\t       const struct adc_sequence *sequence'], 'adc.h', False], [['int adc_read_async', 'const struct device *dev,\n\t\t\t     const struct adc_sequence *sequence,\n\t\t\t     struct k_poll_signal *async'], 'adc.h', False], [['int auxdisplay_display_on', 'const struct device *dev'], 'auxdisplay.h', False], [['int auxdisplay_display_off', 'const struct device *dev'], 'auxdisplay.h', False], [['int auxdisplay_cursor_set_enabled', 'const struct device *dev,\n\t\t\t\t\t    bool enabled'], 'auxdisplay.h', False], [['int auxdisplay_position_blinking_set_enabled', 'const struct device *dev,\n\t\t\t\t\t\t       bool enabled'], 'auxdisplay.h', False], [['int auxdisplay_cursor_shift_set', 'const struct device *dev,\n\t\t\t\t\t  uint8_t direction, bool display_shift'], 'auxdisplay.h', False], [['int auxdisplay_cursor_position_set', 'const struct device *dev,\n\t\t\t\t\t     enum auxdisplay_position type,\n\t\t\t\t\t     int16_t x, int16_t y'], 'auxdisplay.h', False], [['int auxdisplay_cursor_position_get', 'const struct device *dev,\n\t\t\t\t\t     int16_t *x, int16_t *y'], 'auxdisplay.h', False], [['int auxdisplay_display_position_set', 'const struct device *dev,\n\t\t\t\t\t      enum auxdisplay_position type,\n\t\t\t\t\t      int16_t x, int16_t y'], 'auxdisplay.h', False], [['int auxdisplay_display_position_get', 'const struct device *dev,\n\t\t\t\t\t      int16_t *x, int16_t *y'], 'auxdisplay.h', False], [['int auxdisplay_capabilities_get', 'const struct device *dev,\n\t\t\t\t\t  struct auxdisplay_capabilities *capabilities'], 'auxdisplay.h', False], [['int auxdisplay_clear', 'const struct device *dev'], 'auxdisplay.h', False], [['int auxdisplay_brightness_get', 'const struct device *dev,\n\t\t\t\t\tuint8_t *brightness'], 'auxdisplay.h', False], [['int auxdisplay_brightness_set', 'const struct device *dev,\n\t\t\t\t\tuint8_t brightness'], 'auxdisplay.h', False], [['int auxdisplay_backlight_get', 'const struct device *dev,\n\t\t\t\t       uint8_t *backlight'], 'auxdisplay.h', False], [['int auxdisplay_backlight_set', 'const struct device *dev,\n\t\t\t\t       uint8_t backlight'], 'auxdisplay.h', False], [['int auxdisplay_is_busy', 'const struct device *dev'], 'auxdisplay.h', False], [['int auxdisplay_custom_character_set', 'const struct device *dev,\n\t\t\t\t\t      struct auxdisplay_character *character'], 'auxdisplay.h', False], [['int auxdisplay_write', 'const struct device *dev, const uint8_t *data,\n\t\t\t       uint16_t len'], 'auxdisplay.h', False], [['int auxdisplay_custom_command', 'const struct device *dev,\n\t\t\t\t\tstruct auxdisplay_custom_data *data'], 'auxdisplay.h', False], [['int bbram_check_invalid', 'const struct device *dev'], 'bbram.h', False], [['int bbram_check_standby_power', 'const struct device *dev'], 'bbram.h', False], [['int bbram_check_power', 'const struct device *dev'], 'bbram.h', False], [['int bbram_get_size', 'const struct device *dev, size_t *size'], 'bbram.h', False], [['int bbram_read', 'const struct device *dev, size_t offset, size_t size,\n\t\t\t uint8_t *data'], 'bbram.h', False], [['int bbram_write', 'const struct device *dev, size_t offset, size_t size,\n\t\t\t  const uint8_t *data'], 'bbram.h', False], [['int can_get_core_clock', 'const struct device *dev, uint32_t *rate'], 'can.h', False], [['int can_get_max_bitrate', 'const struct device *dev, uint32_t *max_bitrate'], 'can.h', False], [['const struct can_timing *can_get_timing_min', 'const struct device *dev'], 'can.h', False], [['const struct can_timing *can_get_timing_max', 'const struct device *dev'], 'can.h', False], [['int can_calc_timing', 'const struct device *dev, struct can_timing *res,\n\t\t\t      uint32_t bitrate, uint16_t sample_pnt'], 'can.h', False], [['const struct can_timing *can_get_timing_data_min', 'const struct device *dev'], 'can.h', False], [['const struct can_timing *can_get_timing_data_max', 'const struct device *dev'], 'can.h', False], [['int can_calc_timing_data', 'const struct device *dev, struct can_timing *res,\n\t\t\t\t   uint32_t bitrate, uint16_t sample_pnt'], 'can.h', False], [['int can_set_timing_data', 'const struct device *dev,\n\t\t\t\t  const struct can_timing *timing_data'], 'can.h', False], [['int can_set_bitrate_data', 'const struct device *dev, uint32_t bitrate_data'], 'can.h', False], [['int can_set_timing', 'const struct device *dev,\n\t\t\t     const struct can_timing *timing'], 'can.h', False], [['int can_get_capabilities', 'const struct device *dev, can_mode_t *cap'], 'can.h', False], [['int can_start', 'const struct device *dev'], 'can.h', False], [['int can_stop', 'const struct device *dev'], 'can.h', False], [['int can_set_mode', 'const struct device *dev, can_mode_t mode'], 'can.h', False], [['int can_set_bitrate', 'const struct device *dev, uint32_t bitrate'], 'can.h', False], [['int can_send', 'const struct device *dev, const struct can_frame *frame,\n\t\t       k_timeout_t timeout, can_tx_callback_t callback,\n\t\t       void *user_data'], 'can.h', False], [['int can_add_rx_filter_msgq', 'const struct device *dev, struct k_msgq *msgq,\n\t\t\t\t     const struct can_filter *filter'], 'can.h', False], [['void can_remove_rx_filter', 'const struct device *dev, int filter_id'], 'can.h', False], [['int can_get_max_filters', 'const struct device *dev, bool ide'], 'can.h', False], [['int can_get_state', 'const struct device *dev, enum can_state *state,\n\t\t\t    struct can_bus_err_cnt *err_cnt'], 'can.h', False], [['int can_recover', 'const struct device *dev, k_timeout_t timeout'], 'can.h', False], [['bool counter_is_counting_up', 'const struct device *dev'], 'counter.h', False], [['uint8_t counter_get_num_of_channels', 'const struct device *dev'], 'counter.h', False], [['uint32_t counter_get_frequency', 'const struct device *dev'], 'counter.h', False], [['uint32_t counter_us_to_ticks', 'const struct device *dev, uint64_t us'], 'counter.h', False], [['uint64_t counter_ticks_to_us', 'const struct device *dev, uint32_t ticks'], 'counter.h', False], [['uint32_t counter_get_max_top_value', 'const struct device *dev'], 'counter.h', False], [['int counter_start', 'const struct device *dev'], 'counter.h', False], [['int counter_stop', 'const struct device *dev'], 'counter.h', False], [['int counter_get_value', 'const struct device *dev, uint32_t *ticks'], 'counter.h', False], [['int counter_get_value_64', 'const struct device *dev, uint64_t *ticks'], 'counter.h', False], [['int counter_set_channel_alarm', 'const struct device *dev,\n\t\t\t\t\tuint8_t chan_id,\n\t\t\t\t\tconst struct counter_alarm_cfg *alarm_cfg'], 'counter.h', False], [['int counter_cancel_channel_alarm', 'const struct device *dev,\n\t\t\t\t\t   uint8_t chan_id'], 'counter.h', False], [['int counter_set_top_value', 'const struct device *dev,\n\t\t\t\t    const struct counter_top_cfg *cfg'], 'counter.h', False], [['int counter_get_pending_int', 'const struct device *dev'], 'counter.h', False], [['uint32_t counter_get_top_value', 'const struct device *dev'], 'counter.h', False], [['int counter_set_guard_period', 'const struct device *dev,\n\t\t\t\t\tuint32_t ticks,\n\t\t\t\t\tuint32_t flags'], 'counter.h', False], [['uint32_t counter_get_guard_period', 'const struct device *dev,\n\t\t\t\t\t    uint32_t flags'], 'counter.h', False], [['int dac_channel_setup', 'const struct device *dev,\n\t\t\t\tconst struct dac_channel_cfg *channel_cfg'], 'dac.h', False], [['int dac_write_value', 'const struct device *dev, uint8_t channel,\n\t\t\t      uint32_t value'], 'dac.h', False], [['int dma_start', 'const struct device *dev, uint32_t channel'], 'dma.h', False], [['int dma_stop', 'const struct device *dev, uint32_t channel'], 'dma.h', False], [['int dma_suspend', 'const struct device *dev, uint32_t channel'], 'dma.h', False], [['int dma_resume', 'const struct device *dev, uint32_t channel'], 'dma.h', False], [['int dma_request_channel', 'const struct device *dev,\n\t\t\t\t  void *filter_param'], 'dma.h', False], [['void dma_release_channel', 'const struct device *dev,\n\t\t\t\t   uint32_t channel'], 'dma.h', False], [['int dma_chan_filter', 'const struct device *dev,\n\t\t\t\t   int channel, void *filter_param'], 'dma.h', False], [['int eeprom_read', 'const struct device *dev, off_t offset, void *data,\n\t\t\t  size_t len'], 'eeprom.h', False], [['int eeprom_write', 'const struct device *dev, off_t offset,\n\t\t\t   const void *data,\n\t\t\t   size_t len'], 'eeprom.h', False], [['size_t eeprom_get_size', 'const struct device *dev'], 'eeprom.h', False], [['int entropy_get_entropy', 'const struct device *dev,\n\t\t\t\t  uint8_t *buffer,\n\t\t\t\t  uint16_t length'], 'entropy.h', False], [['int espi_config', 'const struct device *dev, struct espi_cfg *cfg'], 'espi.h', False], [['bool espi_get_channel_status', 'const struct device *dev,\n\t\t\t\t       enum espi_channel ch'], 'espi.h', False], [['int espi_read_request', 'const struct device *dev,\n\t\t\t\tstruct espi_request_packet *req'], 'espi.h', False], [['int espi_write_request', 'const struct device *dev,\n\t\t\t\t struct espi_request_packet *req'], 'espi.h', False], [['int espi_read_lpc_request', 'const struct device *dev,\n\t\t\t\t    enum lpc_peripheral_opcode op,\n\t\t\t\t    uint32_t *data'], 'espi.h', False], [['int espi_write_lpc_request', 'const struct device *dev,\n\t\t\t\t     enum lpc_peripheral_opcode op,\n\t\t\t\t     uint32_t *data'], 'espi.h', False], [['int espi_send_vwire', 'const struct device *dev,\n\t\t\t      enum espi_vwire_signal signal,\n\t\t\t      uint8_t level'], 'espi.h', False], [['int espi_receive_vwire', 'const struct device *dev,\n\t\t\t\t enum espi_vwire_signal signal,\n\t\t\t\t uint8_t *level'], 'espi.h', False], [['int espi_send_oob', 'const struct device *dev,\n\t\t\t    struct espi_oob_packet *pckt'], 'espi.h', False], [['int espi_receive_oob', 'const struct device *dev,\n\t\t\t       struct espi_oob_packet *pckt'], 'espi.h', False], [['int espi_read_flash', 'const struct device *dev,\n\t\t\t      struct espi_flash_packet *pckt'], 'espi.h', False], [['int espi_write_flash', 'const struct device *dev,\n\t\t\t       struct espi_flash_packet *pckt'], 'espi.h', False], [['int espi_flash_erase', 'const struct device *dev,\n\t\t\t       struct espi_flash_packet *pckt'], 'espi.h', False], [['int espi_saf_config', 'const struct device *dev,\n\t\t\t      const struct espi_saf_cfg *cfg'], 'espi_saf.h', False], [['int espi_saf_set_protection_regions', '\n\t\t\t\tconst struct device *dev,\n\t\t\t\tconst struct espi_saf_protection *pr'], 'espi_saf.h', False], [['int espi_saf_activate', 'const struct device *dev'], 'espi_saf.h', False], [['bool espi_saf_get_channel_status', 'const struct device *dev'], 'espi_saf.h', False], [['int espi_saf_flash_read', 'const struct device *dev,\n\t\t\t\t  struct espi_saf_packet *pckt'], 'espi_saf.h', False], [['int espi_saf_flash_write', 'const struct device *dev,\n\t\t\t\t   struct espi_saf_packet *pckt'], 'espi_saf.h', False], [['int espi_saf_flash_erase', 'const struct device *dev,\n\t\t\t\t   struct espi_saf_packet *pckt'], 'espi_saf.h', False], [['int flash_read', 'const struct device *dev, off_t offset, void *data,\n\t\t\t size_t len'], 'flash.h', False], [['int flash_write', 'const struct device *dev, off_t offset,\n\t\t\t  const void *data,\n\t\t\t  size_t len'], 'flash.h', False], [['int flash_erase', 'const struct device *dev, off_t offset, size_t size'], 'flash.h', False], [['int flash_get_page_info_by_offs', 'const struct device *dev,\n\t\t\t\t\t  off_t offset,\n\t\t\t\t\t  struct flash_pages_info *info'], 'flash.h', False], [['int flash_get_page_info_by_idx', 'const struct device *dev,\n\t\t\t\t\t uint32_t page_index,\n\t\t\t\t\t struct flash_pages_info *info'], 'flash.h', False], [['size_t flash_get_page_count', 'const struct device *dev'], 'flash.h', False], [['int flash_sfdp_read', 'const struct device *dev, off_t offset,\n\t\t\t      void *data, size_t len'], 'flash.h', False], [['int flash_read_jedec_id', 'const struct device *dev, uint8_t *id'], 'flash.h', False], [['size_t flash_get_write_block_size', 'const struct device *dev'], 'flash.h', False], [['const struct flash_parameters *flash_get_parameters', 'const struct device *dev'], 'flash.h', False], [['int flash_ex_op', 'const struct device *dev, uint16_t code,\n\t\t\t  const uintptr_t in, void *out'], 'flash.h', False], [['int fuel_gauge_get_prop', 'const struct device *dev, struct fuel_gauge_get_property *props,\n\t\t\t\t  size_t props_len'], 'fuel_gauge.h', False], [['int fuel_gauge_set_prop', 'const struct device *dev, struct fuel_gauge_set_property *props,\n\t\t\t\t  size_t props_len'], 'fuel_gauge.h', False], [['int fuel_gauge_get_buffer_prop', 'const struct device *dev,\n\t\t\t\t\tstruct fuel_gauge_get_buffer_property *prop, void *dst,\n\t\t\t\t\tsize_t dst_len'], 'fuel_gauge.h', False], [['int fuel_gauge_battery_cutoff', 'const struct device *dev'], 'fuel_gauge.h', False], [['int gpio_pin_interrupt_configure', 'const struct device *port,\n\t\t\t\t\t   gpio_pin_t pin,\n\t\t\t\t\t   gpio_flags_t flags'], 'gpio.h', False], [['int gpio_pin_configure', 'const struct device *port,\n\t\t\t\t gpio_pin_t pin,\n\t\t\t\t gpio_flags_t flags'], 'gpio.h', False], [['int gpio_port_get_direction', 'const struct device *port, gpio_port_pins_t map,\n\t\t\t\t      gpio_port_pins_t *inputs, gpio_port_pins_t *outputs'], 'gpio.h', False], [['int gpio_pin_get_config', 'const struct device *port, gpio_pin_t pin,\n\t\t\t\t  gpio_flags_t *flags'], 'gpio.h', False], [['int gpio_port_get_raw', 'const struct device *port,\n\t\t\t\tgpio_port_value_t *value'], 'gpio.h', False], [['int gpio_port_set_masked_raw', 'const struct device *port,\n\t\t\t\t       gpio_port_pins_t mask,\n\t\t\t\t       gpio_port_value_t value'], 'gpio.h', False], [['int gpio_port_set_bits_raw', 'const struct device *port,\n\t\t\t\t     gpio_port_pins_t pins'], 'gpio.h', False], [['int gpio_port_clear_bits_raw', 'const struct device *port,\n\t\t\t\t       gpio_port_pins_t pins'], 'gpio.h', False], [['int gpio_port_toggle_bits', 'const struct device *port,\n\t\t\t\t    gpio_port_pins_t pins'], 'gpio.h', False], [['int gpio_get_pending_int', 'const struct device *dev'], 'gpio.h', False], [['ssize_t hwinfo_get_device_id', 'uint8_t *buffer, size_t length'], 'hwinfo.h', False], [['int hwinfo_get_reset_cause', 'uint32_t *cause'], 'hwinfo.h', False], [['int hwinfo_clear_reset_cause', 'void'], 'hwinfo.h', False], [['int hwinfo_get_supported_reset_cause', 'uint32_t *supported'], 'hwinfo.h', False], [['int hwspinlock_trylock', 'const struct device *dev, uint32_t id'], 'hwspinlock.h', False], [['void hwspinlock_lock', 'const struct device *dev, uint32_t id'], 'hwspinlock.h', False], [['void hwspinlock_unlock', 'const struct device *dev, uint32_t id'], 'hwspinlock.h', False], [['uint32_t hwspinlock_get_max_id', 'const struct device *dev'], 'hwspinlock.h', False], [['int i2c_configure', 'const struct device *dev, uint32_t dev_config'], 'i2c.h', False], [['int i2c_get_config', 'const struct device *dev, uint32_t *dev_config'], 'i2c.h', False], [['int i2c_transfer', 'const struct device *dev,\n\t\t\t   struct i2c_msg *msgs, uint8_t num_msgs,\n\t\t\t   uint16_t addr'], 'i2c.h', False], [['int i2c_recover_bus', 'const struct device *dev'], 'i2c.h', False], [['int i2c_target_driver_register', 'const struct device *dev'], 'i2c.h', False], [['int i2c_target_driver_unregister', 'const struct device *dev'], 'i2c.h', False], [['int i2s_configure', 'const struct device *dev, enum i2s_dir dir,\n\t\t\t    const struct i2s_config *cfg'], 'i2s.h', False], [['int i2s_buf_read', 'const struct device *dev, void *buf, size_t *size'], 'i2s.h', False], [['int i2s_buf_write', 'const struct device *dev, void *buf, size_t size'], 'i2s.h', False], [['int i2s_trigger', 'const struct device *dev, enum i2s_dir dir,\n\t\t\t  enum i2s_trigger_cmd cmd'], 'i2s.h', False], [['int i3c_do_ccc', 'const struct device *dev,\n\t\t\t struct i3c_ccc_payload *payload'], 'i3c.h', False], [['int i3c_transfer', 'struct i3c_device_desc *target,\n\t\t\t   struct i3c_msg *msgs, uint8_t num_msgs'], 'i3c.h', False], [['int ipm_send', 'const struct device *ipmdev, int wait, uint32_t id,\n\t\t       const void *data, int size'], 'ipm.h', False], [['int ipm_max_data_size_get', 'const struct device *ipmdev'], 'ipm.h', False], [['uint32_t ipm_max_id_val_get', 'const struct device *ipmdev'], 'ipm.h', False], [['int ipm_set_enabled', 'const struct device *ipmdev, int enable'], 'ipm.h', False], [['void ipm_complete', 'const struct device *ipmdev'], 'ipm.h', False], [['int kscan_config', 'const struct device *dev,\n\t\t\t     kscan_callback_t callback'], 'kscan.h', False], [['int kscan_enable_callback', 'const struct device *dev'], 'kscan.h', False], [['int kscan_disable_callback', 'const struct device *dev'], 'kscan.h', False], [['int led_blink', 'const struct device *dev, uint32_t led,\n\t\t\t    uint32_t delay_on, uint32_t delay_off'], 'led.h', False], [['int led_get_info', 'const struct device *dev, uint32_t led,\n\t\t\t   const struct led_info **info'], 'led.h', False], [['int led_set_brightness', 'const struct device *dev, uint32_t led,\n\t\t\t\t     uint8_t value'], 'led.h', False], [['int led_write_channels', 'const struct device *dev,\n\t\t\t\t uint32_t start_channel,\n\t\t\t\t uint32_t num_channels, const uint8_t *buf'], 'led.h', False], [['int led_set_channel', 'const struct device *dev,\n\t\t\t      uint32_t channel, uint8_t value'], 'led.h', False], [['int led_set_color', 'const struct device *dev, uint32_t led,\n\t\t\t    uint8_t num_colors, const uint8_t *color'], 'led.h', False], [['int led_on', 'const struct device *dev, uint32_t led'], 'led.h', False], [['int led_off', 'const struct device *dev, uint32_t led'], 'led.h', False], [['int mbox_send', 'const struct mbox_channel *channel, const struct mbox_msg *msg'], 'mbox.h', False], [['int mbox_mtu_get', 'const struct device *dev'], 'mbox.h', False], [['int mbox_set_enabled', 'const struct mbox_channel *channel, bool enable'], 'mbox.h', False], [['uint32_t mbox_max_channels_get', 'const struct device *dev'], 'mbox.h', False], [['void mdio_bus_enable', 'const struct device *dev'], 'mdio.h', False], [['void mdio_bus_disable', 'const struct device *dev'], 'mdio.h', False], [['int mdio_read', 'const struct device *dev, uint8_t prtad, uint8_t devad,\n\t\t\tuint16_t *data'], 'mdio.h', False], [['int mdio_write', 'const struct device *dev, uint8_t prtad, uint8_t devad,\n\t\t\t uint16_t data'], 'mdio.h', False], [['int peci_config', 'const struct device *dev, uint32_t bitrate'], 'peci.h', False], [['int peci_enable', 'const struct device *dev'], 'peci.h', False], [['int peci_disable', 'const struct device *dev'], 'peci.h', False], [['int peci_transfer', 'const struct device *dev, struct peci_msg *msg'], 'peci.h', False], [['int ps2_config', 'const struct device *dev,\n\t\t\t ps2_callback_t callback_isr'], 'ps2.h', False], [['int ps2_write', 'const struct device *dev, uint8_t value'], 'ps2.h', False], [['int ps2_read', 'const struct device *dev,  uint8_t *value'], 'ps2.h', False], [['int ps2_enable_callback', 'const struct device *dev'], 'ps2.h', False], [['int ps2_disable_callback', 'const struct device *dev'], 'ps2.h', False], [['int ptp_clock_get', 'const struct device *dev, struct net_ptp_time *tm'], 'ptp_clock.h', False], [['int pwm_set_cycles', 'const struct device *dev, uint32_t channel,\n\t\t\t     uint32_t period, uint32_t pulse,\n\t\t\t     pwm_flags_t flags'], 'pwm.h', False], [['int pwm_get_cycles_per_sec', 'const struct device *dev, uint32_t channel,\n\t\t\t\t     uint64_t *cycles'], 'pwm.h', False], [['int pwm_enable_capture', 'const struct device *dev, uint32_t channel'], 'pwm.h', False], [['int pwm_disable_capture', 'const struct device *dev, uint32_t channel'], 'pwm.h', False], [['int pwm_capture_cycles', 'const struct device *dev, uint32_t channel,\n\t\t\t\t pwm_flags_t flags, uint32_t *period,\n\t\t\t\t uint32_t *pulse, k_timeout_t timeout'], 'pwm.h', False], [['int reset_status', 'const struct device *dev, uint32_t id, uint8_t *status'], 'reset.h', False], [['int reset_line_assert', 'const struct device *dev, uint32_t id'], 'reset.h', False], [['int reset_line_deassert', 'const struct device *dev, uint32_t id'], 'reset.h', False], [['int reset_line_toggle', 'const struct device *dev, uint32_t id'], 'reset.h', False], [['ssize_t retained_mem_size', 'const struct device *dev'], 'retained_mem.h', False], [['int retained_mem_read', 'const struct device *dev, off_t offset, uint8_t *buffer,\n\t\t\t\tsize_t size'], 'retained_mem.h', False], [['int retained_mem_write', 'const struct device *dev, off_t offset, const uint8_t *buffer,\n\t\t\t\t size_t size'], 'retained_mem.h', False], [['int retained_mem_clear', 'const struct device *dev'], 'retained_mem.h', False], [['int rtc_set_time', 'const struct device *dev, const struct rtc_time *timeptr'], 'rtc.h', False], [['int rtc_get_time', 'const struct device *dev, struct rtc_time *timeptr'], 'rtc.h', False], [['int rtc_alarm_get_supported_fields', 'const struct device *dev, uint16_t id,\n\t\t\t\t\t     uint16_t *mask'], 'rtc.h', False], [['int rtc_alarm_set_time', 'const struct device *dev, uint16_t id, uint16_t mask,\n\t\t\t\t const struct rtc_time *timeptr'], 'rtc.h', False], [['int rtc_alarm_get_time', 'const struct device *dev, uint16_t id, uint16_t *mask,\n\t\t\t\t struct rtc_time *timeptr'], 'rtc.h', False], [['int rtc_alarm_is_pending', 'const struct device *dev, uint16_t id'], 'rtc.h', False], [['int rtc_alarm_set_callback', 'const struct device *dev, uint16_t id,\n\t\t\t\t     rtc_alarm_callback callback, void *user_data'], 'rtc.h', False], [['int rtc_update_set_callback', 'const struct device *dev, rtc_update_callback callback,\n\t\t\t\t      void *user_data'], 'rtc.h', False], [['int rtc_set_calibration', 'const struct device *dev, int32_t calibration'], 'rtc.h', False], [['int rtc_get_calibration', 'const struct device *dev, int32_t *calibration'], 'rtc.h', False], [['int sdhc_hw_reset', 'const struct device *dev'], 'sdhc.h', False], [['int sdhc_request', 'const struct device *dev, struct sdhc_command *cmd,\n\t\tstruct sdhc_data *data'], 'sdhc.h', False], [['int sdhc_set_io', 'const struct device *dev, struct sdhc_io *io'], 'sdhc.h', False], [['int sdhc_card_present', 'const struct device *dev'], 'sdhc.h', False], [['int sdhc_execute_tuning', 'const struct device *dev'], 'sdhc.h', False], [['int sdhc_card_busy', 'const struct device *dev'], 'sdhc.h', False], [['int sdhc_get_host_props', 'const struct device *dev,\n\tstruct sdhc_host_props *props'], 'sdhc.h', False], [['int sensor_attr_set', 'const struct device *dev,\n\t\t\t      enum sensor_channel chan,\n\t\t\t      enum sensor_attribute attr,\n\t\t\t      const struct sensor_value *val'], 'sensor.h', False], [['int sensor_attr_get', 'const struct device *dev,\n\t\t\t      enum sensor_channel chan,\n\t\t\t      enum sensor_attribute attr,\n\t\t\t      struct sensor_value *val'], 'sensor.h', False], [['int sensor_sample_fetch', 'const struct device *dev'], 'sensor.h', False], [['int sensor_sample_fetch_chan', 'const struct device *dev,\n\t\t\t\t       enum sensor_channel type'], 'sensor.h', False], [['int sensor_channel_get', 'const struct device *dev,\n\t\t\t\t enum sensor_channel chan,\n\t\t\t\t struct sensor_value *val'], 'sensor.h', False], [['int sensor_get_decoder', 'const struct device *dev,\n\t\t\t\t const struct sensor_decoder_api **decoder'], 'sensor.h', False], [['int sensor_reconfigure_read_iodev', 'struct rtio_iodev *iodev, const struct device *sensor,\n\t\t\t\t\t    const enum sensor_channel *channels,\n\t\t\t\t\t    size_t num_channels'], 'sensor.h', False], [['int smbus_configure', 'const struct device *dev, uint32_t dev_config'], 'smbus.h', False], [['int smbus_get_config', 'const struct device *dev, uint32_t *dev_config'], 'smbus.h', False], [['int smbus_smbalert_set_cb', 'const struct device *dev,\n\t\t\t\t    struct smbus_callback *cb'], 'smbus.h', False], [['int smbus_smbalert_remove_cb', 'const struct device *dev,\n\t\t\t\t       struct smbus_callback *cb'], 'smbus.h', False], [['int smbus_host_notify_set_cb', 'const struct device *dev,\n\t\t\t\t       struct smbus_callback *cb'], 'smbus.h', False], [['int smbus_host_notify_remove_cb', 'const struct device *dev,\n\t\t\t\t\t  struct smbus_callback *cb'], 'smbus.h', False], [['int smbus_quick', 'const struct device *dev, uint16_t addr,\n\t\t\t  enum smbus_direction direction'], 'smbus.h', False], [['int smbus_byte_write', 'const struct device *dev, uint16_t addr,\n\t\t\t       uint8_t byte'], 'smbus.h', False], [['int smbus_byte_read', 'const struct device *dev, uint16_t addr,\n\t\t\t      uint8_t *byte'], 'smbus.h', False], [['int smbus_byte_data_write', 'const struct device *dev, uint16_t addr,\n\t\t\t\t    uint8_t cmd, uint8_t byte'], 'smbus.h', False], [['int smbus_byte_data_read', 'const struct device *dev, uint16_t addr,\n\t\t\t\t   uint8_t cmd, uint8_t *byte'], 'smbus.h', False], [['int smbus_word_data_write', 'const struct device *dev, uint16_t addr,\n\t\t\t\t    uint8_t cmd, uint16_t word'], 'smbus.h', False], [['int smbus_word_data_read', 'const struct device *dev, uint16_t addr,\n\t\t\t\t   uint8_t cmd, uint16_t *word'], 'smbus.h', False], [['int smbus_pcall', 'const struct device *dev, uint16_t addr,\n\t\t\t  uint8_t cmd, uint16_t send_word, uint16_t *recv_word'], 'smbus.h', False], [['int smbus_block_write', 'const struct device *dev, uint16_t addr,\n\t\t\t\tuint8_t cmd, uint8_t count, uint8_t *buf'], 'smbus.h', False], [['int smbus_block_read', 'const struct device *dev, uint16_t addr,\n\t\t\t       uint8_t cmd, uint8_t *count, uint8_t *buf'], 'smbus.h', False], [['int smbus_block_pcall', 'const struct device *dev,\n\t\t\t\tuint16_t addr, uint8_t cmd,\n\t\t\t\tuint8_t snd_count, uint8_t *snd_buf,\n\t\t\t\tuint8_t *rcv_count, uint8_t *rcv_buf'], 'smbus.h', False], [['int spi_transceive', 'const struct device *dev,\n\t\t\t     const struct spi_config *config,\n\t\t\t     const struct spi_buf_set *tx_bufs,\n\t\t\t     const struct spi_buf_set *rx_bufs'], 'spi.h', False], [['int spi_release', 'const struct device *dev,\n\t\t\t  const struct spi_config *config'], 'spi.h', False], [['int syscon_get_base', 'const struct device *dev, uintptr_t *addr'], 'syscon.h', False], [['int syscon_read_reg', 'const struct device *dev, uint16_t reg, uint32_t *val'], 'syscon.h', False], [['int syscon_write_reg', 'const struct device *dev, uint16_t reg, uint32_t val'], 'syscon.h', False], [['int syscon_get_size', 'const struct device *dev, size_t *size'], 'syscon.h', False], [['int w1_change_bus_lock', 'const struct device *dev, bool lock'], 'w1.h', False], [['int w1_reset_bus', 'const struct device *dev'], 'w1.h', False], [['int w1_read_bit', 'const struct device *dev'], 'w1.h', False], [['int w1_write_bit', 'const struct device *dev, const bool bit'], 'w1.h', False], [['int w1_read_byte', 'const struct device *dev'], 'w1.h', False], [['int w1_write_byte', 'const struct device *dev, uint8_t byte'], 'w1.h', False], [['int w1_read_block', 'const struct device *dev, uint8_t *buffer, size_t len'], 'w1.h', False], [['int w1_write_block', 'const struct device *dev,\n\t\t\t     const uint8_t *buffer, size_t len'], 'w1.h', False], [['size_t w1_get_slave_count', 'const struct device *dev'], 'w1.h', False], [['int w1_configure', 'const struct device *dev,\n\t\t\t   enum w1_settings_type type, uint32_t value'], 'w1.h', False], [['int w1_search_bus', 'const struct device *dev, uint8_t command,\n\t\t\t    uint8_t family, w1_search_callback_t callback,\n\t\t\t    void *user_data'], 'w1.h', False], [['int wdt_setup', 'const struct device *dev, uint8_t options'], 'watchdog.h', False], [['int wdt_disable', 'const struct device *dev'], 'watchdog.h', False], [['int wdt_feed', 'const struct device *dev, int channel_id'], 'watchdog.h', False], [['const struct device *uart_mux_find', 'int dlci_address'], 'uart_mux.h', False], [['void *flash_simulator_get_memory', 'const struct device *dev,\n\t\t\t\t\t   size_t *mock_size'], 'flash_simulator.h', False], [['void nrf_qspi_nor_xip_enable', 'const struct device *dev, bool enable'], 'nrf_qspi_nor.h', False], [['int maxim_ds3231_req_syncpoint', 'const struct device *dev,\n\t\t\t\t\t struct k_poll_signal *signal'], 'maxim_ds3231.h', False], [['int maxim_ds3231_get_syncpoint', 'const struct device *dev,\n\t\t\t\t\t struct maxim_ds3231_syncpoint *syncpoint'], 'maxim_ds3231.h', False], [['void sip_supervisory_call', 'const struct device *dev, unsigned long function_id,\n\t\t\t\t    unsigned long arg0, unsigned long arg1, unsigned long arg2,\n\t\t\t\t    unsigned long arg3, unsigned long arg4, unsigned long arg5,\n\t\t\t\t    unsigned long arg6, struct arm_smccc_res *res'], 'sip_svc_driver.h', False], [['bool sip_svc_plat_func_id_valid', 'const struct device *dev, uint32_t command,\n\t\t\t\t\t  uint32_t func_id'], 'sip_svc_driver.h', False], [['uint32_t sip_svc_plat_format_trans_id', 'const struct device *dev, uint32_t client_idx,\n\t\t\t\t\t\tuint32_t trans_idx'], 'sip_svc_driver.h', False], [['uint32_t sip_svc_plat_get_trans_idx', 'const struct device *dev, uint32_t trans_id'], 'sip_svc_driver.h', False], [['void sip_svc_plat_update_trans_id', 'const struct device *dev,\n\t\t\t\t\t    struct sip_svc_request *request, uint32_t trans_id'], 'sip_svc_driver.h', False], [['uint32_t sip_svc_plat_get_error_code', 'const struct device *dev, struct arm_smccc_res *res'], 'sip_svc_driver.h', False], [['int sip_svc_plat_async_res_req', 'const struct device *dev, unsigned long *a0,\n\t\t\t\t\t unsigned long *a1, unsigned long *a2, unsigned long *a3,\n\t\t\t\t\t unsigned long *a4, unsigned long *a5, unsigned long *a6,\n\t\t\t\t\t unsigned long *a7, char *buf, size_t size'], 'sip_svc_driver.h', False], [['int sip_svc_plat_async_res_res', 'const struct device *dev, struct arm_smccc_res *res,\n\t\t\t\t\t char *buf, size_t *size, uint32_t *trans_id'], 'sip_svc_driver.h', False], [['void sip_svc_plat_free_async_memory', 'const struct device *dev,\n\t\t\t\t\t      struct sip_svc_request *request'], 'sip_svc_driver.h', False], [['int bc12_set_role', 'const struct device *dev, enum bc12_role role'], 'usb_bc12.h', False], [['int bc12_set_result_cb', 'const struct device *dev, bc12_callback_t cb, void *user_data'], 'usb_bc12.h', False], [['size_t ivshmem_get_mem', 'const struct device *dev,\n\t\t\t\t uintptr_t *memmap'], 'ivshmem.h', False], [['uint32_t ivshmem_get_id', 'const struct device *dev'], 'ivshmem.h', False], [['uint16_t ivshmem_get_vectors', 'const struct device *dev'], 'ivshmem.h', False], [['int ivshmem_int_peer', 'const struct device *dev,\n\t\t\t       uint32_t peer_id, uint16_t vector'], 'ivshmem.h', False], [['int ivshmem_register_handler', 'const struct device *dev,\n\t\t\t\t       struct k_poll_signal *signal,\n\t\t\t\t       uint16_t vector'], 'ivshmem.h', False], [['size_t ivshmem_get_rw_mem_section', 'const struct device *dev,\n\t\t\t\t\t    uintptr_t *memmap'], 'ivshmem.h', False], [['size_t ivshmem_get_output_mem_section', 'const struct device *dev,\n\t\t\t\t\t\tuint32_t peer_id,\n\t\t\t\t\t\tuintptr_t *memmap'], 'ivshmem.h', False], [['uint32_t ivshmem_get_state', 'const struct device *dev,\n\t\t\t\t     uint32_t peer_id'], 'ivshmem.h', False], [['int ivshmem_set_state', 'const struct device *dev,\n\t\t\t\tuint32_t state'], 'ivshmem.h', False], [['uint32_t ivshmem_get_max_peers', 'const struct device *dev'], 'ivshmem.h', False], [['uint16_t ivshmem_get_protocol', 'const struct device *dev'], 'ivshmem.h', False], [['int ivshmem_enable_interrupts', 'const struct device *dev,\n\t\t\t\t\tbool enable'], 'ivshmem.h', False], [['void updatehub_autohandler', 'void'], 'updatehub.h', False], [['enum updatehub_response updatehub_probe', 'void'], 'updatehub.h', False], [['enum updatehub_response updatehub_update', 'void'], 'updatehub.h', False], [['int updatehub_confirm', 'void'], 'updatehub.h', False], [['int updatehub_reboot', 'void'], 'updatehub.h', False], [['const struct device *net_eth_get_ptp_clock_by_index', 'int index'], 'ethernet.h', False], [['int net_if_ipv6_addr_lookup_by_index', 'const struct in6_addr *addr'], 'net_if.h', False], [['bool net_if_ipv6_addr_add_by_index', 'int index,\n\t\t\t\t\t     struct in6_addr *addr,\n\t\t\t\t\t     enum net_addr_type addr_type,\n\t\t\t\t\t     uint32_t vlifetime'], 'net_if.h', False], [['bool net_if_ipv6_addr_rm_by_index', 'int index,\n\t\t\t\t\t    const struct in6_addr *addr'], 'net_if.h', False], [['int net_if_ipv4_addr_lookup_by_index', 'const struct in_addr *addr'], 'net_if.h', False], [['bool net_if_ipv4_addr_add_by_index', 'int index,\n\t\t\t\t\t     struct in_addr *addr,\n\t\t\t\t\t     enum net_addr_type addr_type,\n\t\t\t\t\t     uint32_t vlifetime'], 'net_if.h', False], [['bool net_if_ipv4_addr_rm_by_index', 'int index,\n\t\t\t\t\t    const struct in_addr *addr'], 'net_if.h', False], [['bool net_if_ipv4_set_netmask_by_index', 'int index,\n\t\t\t\t\t\tconst struct in_addr *netmask'], 'net_if.h', False], [['bool net_if_ipv4_set_gw_by_index', 'int index, const struct in_addr *gw'], 'net_if.h', False], [['struct net_if *net_if_get_by_index', 'int index'], 'net_if.h', False], [['int net_addr_pton', 'sa_family_t family, const char *src, void *dst'], 'net_ip.h', False], [['char *net_addr_ntop', 'sa_family_t family, const void *src,\n\t\t\t      char *dst, size_t size'], 'net_ip.h', False], [['int phy_configure_link', 'const struct device *dev,\n\t\t\t\t enum phy_link_speed speeds'], 'phy.h', False], [['int phy_get_link_state', 'const struct device *dev,\n\t\t\t\t struct phy_link_state *state'], 'phy.h', False], [['int phy_link_callback_set', 'const struct device *dev,\n\t\t\t\t    phy_callback_t callback,\n\t\t\t\t    void *user_data'], 'phy.h', False], [['int phy_read', 'const struct device *dev, uint16_t reg_addr,\n\t\t       uint32_t *value'], 'phy.h', False], [['int phy_write', 'const struct device *dev, uint16_t reg_addr,\n\t\t\tuint32_t value'], 'phy.h', False], [['void *zsock_get_context_object', 'int sock'], 'socket.h', False], [['int zsock_socket', 'int family, int type, int proto'], 'socket.h', False], [['int zsock_socketpair', 'int family, int type, int proto, int *sv'], 'socket.h', False], [['int zsock_close', 'int sock'], 'socket.h', False], [['int zsock_shutdown', 'int sock, int how'], 'socket.h', False], [['int zsock_bind', 'int sock, const struct sockaddr *addr,\n\t\t\t socklen_t addrlen'], 'socket.h', False], [['int zsock_connect', 'int sock, const struct sockaddr *addr,\n\t\t\t    socklen_t addrlen'], 'socket.h', False], [['int zsock_listen', 'int sock, int backlog'], 'socket.h', False], [['int zsock_accept', 'int sock, struct sockaddr *addr, socklen_t *addrlen'], 'socket.h', False], [['ssize_t zsock_sendto', 'int sock, const void *buf, size_t len,\n\t\t\t       int flags, const struct sockaddr *dest_addr,\n\t\t\t       socklen_t addrlen'], 'socket.h', False], [['ssize_t zsock_sendmsg', 'int sock, const struct msghdr *msg,\n\t\t\t\tint flags'], 'socket.h', False], [['ssize_t zsock_recvfrom', 'int sock, void *buf, size_t max_len,\n\t\t\t\t int flags, struct sockaddr *src_addr,\n\t\t\t\t socklen_t *addrlen'], 'socket.h', False], [['int zsock_fcntl', 'int sock, int cmd, int flags'], 'socket.h', False], [['int zsock_ioctl', 'int sock, unsigned long request, va_list ap'], 'socket.h', False], [['int zsock_poll', 'struct zsock_pollfd *fds, int nfds, int timeout'], 'socket.h', False], [['int zsock_getsockopt', 'int sock, int level, int optname,\n\t\t\t       void *optval, socklen_t *optlen'], 'socket.h', False], [['int zsock_setsockopt', 'int sock, int level, int optname,\n\t\t\t       const void *optval, socklen_t optlen'], 'socket.h', False], [['int zsock_getpeername', 'int sock, struct sockaddr *addr,\n\t\t\t\tsocklen_t *addrlen'], 'socket.h', False], [['int zsock_getsockname', 'int sock, struct sockaddr *addr,\n\t\t\t\tsocklen_t *addrlen'], 'socket.h', False], [['int zsock_gethostname', 'char *buf, size_t len'], 'socket.h', False], [['int zsock_inet_pton', 'sa_family_t family, const char *src, void *dst'], 'socket.h', False], [['int z_zsock_getaddrinfo_internal', 'const char *host,\n\t\t\t\t\t   const char *service,\n\t\t\t\t\t   const struct zsock_addrinfo *hints,\n\t\t\t\t\t   struct zsock_addrinfo *res'], 'socket.h', False], [['int zsock_select', 'int nfds, zsock_fd_set *readfds,\n\t\t\t   zsock_fd_set *writefds,\n\t\t\t   zsock_fd_set *exceptfds,\n\t\t\t   struct zsock_timeval *timeout'], 'socket_select.h', False], [['int rtio_cqe_get_mempool_buffer', 'const struct rtio *r, struct rtio_cqe *cqe,\n\t\t\t\t\t  uint8_t **buff, uint32_t *buff_len'], 'rtio.h', False], [['void rtio_release_buffer', 'struct rtio *r, void *buff, uint32_t buff_len'], 'rtio.h', False], [['int rtio_sqe_cancel', 'struct rtio_sqe *sqe'], 'rtio.h', False], [['int rtio_sqe_copy_in_get_handles', 'struct rtio *r, const struct rtio_sqe *sqes,\n\t\t\t\t\t   struct rtio_sqe **handle, size_t sqe_count'], 'rtio.h', False], [['int rtio_cqe_copy_out', 'struct rtio *r,\n\t\t\t\tstruct rtio_cqe *cqes,\n\t\t\t\tsize_t cqe_count,\n\t\t\t\tk_timeout_t timeout'], 'rtio.h', False], [['int rtio_submit', 'struct rtio *r, uint32_t wait_count'], 'rtio.h', False], [['bool atomic_cas', 'atomic_t *target, atomic_val_t old_value,\n\t\t\t atomic_val_t new_value'], 'atomic_c.h', False], [['bool atomic_ptr_cas', 'atomic_ptr_t *target, atomic_ptr_val_t old_value,\n\t\t\t      atomic_ptr_val_t new_value'], 'atomic_c.h', False], [['atomic_val_t atomic_add', 'atomic_t *target, atomic_val_t value'], 'atomic_c.h', False], [['atomic_val_t atomic_sub', 'atomic_t *target, atomic_val_t value'], 'atomic_c.h', False], [['atomic_val_t atomic_set', 'atomic_t *target, atomic_val_t value'], 'atomic_c.h', False], [['atomic_ptr_val_t atomic_ptr_set', 'atomic_ptr_t *target, atomic_ptr_val_t value'], 'atomic_c.h', False], [['atomic_val_t atomic_or', 'atomic_t *target, atomic_val_t value'], 'atomic_c.h', False], [['atomic_val_t atomic_xor', 'atomic_t *target, atomic_val_t value'], 'atomic_c.h', False], [['atomic_val_t atomic_and', 'atomic_t *target, atomic_val_t value'], 'atomic_c.h', False], [['atomic_val_t atomic_nand', 'atomic_t *target, atomic_val_t value'], 'atomic_c.h', False], [['int *z_errno', 'void'], 'errno_private.h', False]]
```