### PR TITLE
Zephyr 3.7 support. Drop older 3.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        zephyr_version: [3.6.0, 3.5.0, 3.4.0, 2.7.3, 2.3.0]
+        zephyr_version: [3.7.0, 2.7.3, 2.3.0]
         board: [qemu_x86, qemu_cortex_m3, qemu_cortex_r5, nucleo_l552ze_q, native_posix, qemu_riscv32, qemu_riscv64]
         test: [samples/rust-app, samples/no_std, samples/serial]
         exclude:
@@ -21,27 +21,15 @@ jobs:
           - board: qemu_riscv64
             zephyr_version: 2.3.0
           - board: qemu_riscv32
-            zephyr_version: 2.4.0
-          - board: qemu_riscv64
-            zephyr_version: 2.4.0
-          - board: qemu_riscv32
-            zephyr_version: 2.5.0
-          - board: qemu_riscv64
-            zephyr_version: 2.5.0
-          - board: qemu_riscv32
-            zephyr_version: 2.6.0
-          - board: qemu_riscv64
-            zephyr_version: 2.6.0
-          - board: qemu_riscv32
             zephyr_version: 2.7.3
           - board: qemu_riscv64
             zephyr_version: 2.7.3
+          # serial/uart does not exist on posix
           - board: native_posix
             test: samples/serial
+          # posix has header issues on Zephyr 3.x
           - board: native_posix
-            zephyr_version: 3.5.0
-          - board: native_posix
-            zephyr_version: 3.6.0
+            zephyr_version: 3.7.0
         include:
           - fails: false
           - run: false

--- a/Kconfig
+++ b/Kconfig
@@ -1,12 +1,26 @@
 menuconfig RUST
 	bool "Rust"
 	select THREAD_CUSTOM_DATA
-	select CPLUSPLUS
-	select PICOLIBC_USE_MODULE if PICOLIBC
+	# Static initializers for Zephyr >=3.7
+	select STATIC_INIT_GNU if TOOLCHAIN_SUPPORTS_STATIC_INIT_GNU
+	# Static initializers for Zephyr 2.x
+	select CPLUSPLUS if !TOOLCHAIN_SUPPORTS_STATIC_INIT_GNU
 	help
 	  Rust language support.
 
 if RUST
+
+# Define this choice to use PICOLIBC_USE_MODULE on 3.7 and be compatible with 2.x
+# This breaks older 3.x versions because PICOLIBC_SOURCE is not a choice there
+# It is not possible to use 'select' with a 'choice'
+choice PICOLIBC_SOURCE
+	prompt "Source of Picolibc"
+	default PICOLIBC_USE_MODULE
+
+config PICOLIBC_USE_MODULE
+	bool "Picolibc from module"
+endchoice
+
 choice RUST_GLOBAL_ALLOCATOR
 	prompt "Rust global allocator"
 	default RUST_ALLOC_POOL if USERSPACE


### PR DESCRIPTION
Issues with 3.x prior to 3.7:

picolibc:
I was not able to get Kconfig to build picolibc from source in a way that was compatible with both 3.7 and prior versions of 3.x due to Zephyr changing PICOLIBC_USE_MODULE from a bool to a choice. Setting options in each prj.conf also doesn't work because it generates warnings for undefined symbols in older versions. If there were some way to have version-conditional behavior in Kconfig, that would make it possible to bring back older 3.x compat.

ctors:
zephyr-macros uses ctors to run init code. This required setting CONFIG_CPLUSPLUS. That has been deprecated and removed in 3.7, but there is now a separate option, CONFIG_STATIC_INIT_GNU, that runs ctors. TOOLCHAIN_SUPPORTS_STATIC_INIT_GNU happened to be added in the same commit, so we can use this to distinguish between setting CPLUSPLUS on 2.x and STATIC_INIT_GNU on 3.7. Prior to 3.7, STATIC_INIT_GNU does not exist and CPLUSPLUS conflicts with PICOLIBC_USE_MODULE. It might be possible to avoid this mess by not relying on C++ ctors.